### PR TITLE
keep the console open after sample is stopped

### DIFF
--- a/PollyTestClient/Program.cs
+++ b/PollyTestClient/Program.cs
@@ -66,6 +66,7 @@ namespace PollyTestClient
             // Keep the console open.
             Console.ReadLine();
             cancellationTokenSource.Cancel();
+            Console.ReadLine();
         }
     }
 }


### PR DESCRIPTION
There're Console.KeyAvailable in AsyncDemo00_NoPolicy.ExecuteAsync and Console.Readline() in Program.Main as well, so after key is pressed in console the AsyncDemo00_NoPolicy stop and console is closed  immediately. As a result,  the summary info has no chance to show in console.