### PR TITLE
Removing unnecessary null validation for CancellationToken

### DIFF
--- a/PollyDemos/Async/AsyncDemo00_NoPolicy.cs
+++ b/PollyDemos/Async/AsyncDemo00_NoPolicy.cs
@@ -23,7 +23,6 @@ namespace PollyDemos.Async
 
         public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (cancellationToken == null) throw new ArgumentNullException(nameof(cancellationToken));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
 
             eventualSuccesses = 0;

--- a/PollyDemos/Async/AsyncDemo01_RetryNTimes.cs
+++ b/PollyDemos/Async/AsyncDemo01_RetryNTimes.cs
@@ -27,7 +27,6 @@ namespace PollyDemos.Async
 
         public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (cancellationToken == null) throw new ArgumentNullException(nameof(cancellationToken));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
 
             eventualSuccesses = 0;

--- a/PollyDemos/Async/AsyncDemo02_WaitAndRetryNTimes.cs
+++ b/PollyDemos/Async/AsyncDemo02_WaitAndRetryNTimes.cs
@@ -28,7 +28,6 @@ namespace PollyDemos.Async
 
         public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (cancellationToken == null) throw new ArgumentNullException(nameof(cancellationToken));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
 
             eventualSuccesses = 0;

--- a/PollyDemos/Async/AsyncDemo03_WaitAndRetryNTimes_WithEnoughRetries.cs
+++ b/PollyDemos/Async/AsyncDemo03_WaitAndRetryNTimes_WithEnoughRetries.cs
@@ -28,7 +28,6 @@ namespace PollyDemos.Async
 
         public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (cancellationToken == null) throw new ArgumentNullException(nameof(cancellationToken));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
 
             // Let's call a web api service to make repeated requests to a server. 

--- a/PollyDemos/Async/AsyncDemo04_WaitAndRetryForever.cs
+++ b/PollyDemos/Async/AsyncDemo04_WaitAndRetryForever.cs
@@ -30,7 +30,6 @@ namespace PollyDemos.Async
 
         public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (cancellationToken == null) throw new ArgumentNullException(nameof(cancellationToken));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
 
             // Let's call a web api service to make repeated requests to a server. 

--- a/PollyDemos/Async/AsyncDemo05_WaitAndRetryWithExponentialBackoff.cs
+++ b/PollyDemos/Async/AsyncDemo05_WaitAndRetryWithExponentialBackoff.cs
@@ -32,7 +32,6 @@ namespace PollyDemos.Async
 
         public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (cancellationToken == null) throw new ArgumentNullException(nameof(cancellationToken));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
 
             // Let's call a web api service to make repeated requests to a server. 

--- a/PollyDemos/Async/AsyncDemo06_WaitAndRetryNestingCircuitBreaker.cs
+++ b/PollyDemos/Async/AsyncDemo06_WaitAndRetryNestingCircuitBreaker.cs
@@ -41,7 +41,6 @@ namespace PollyDemos.Async
 
         public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (cancellationToken == null) throw new ArgumentNullException(nameof(cancellationToken));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
 
             // Let's call a web api service to make repeated requests to a server. 

--- a/PollyDemos/Async/AsyncDemo07_WaitAndRetryNestingCircuitBreakerUsingPolicyWrap.cs
+++ b/PollyDemos/Async/AsyncDemo07_WaitAndRetryNestingCircuitBreakerUsingPolicyWrap.cs
@@ -34,7 +34,6 @@ namespace PollyDemos.Async
 
         public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (cancellationToken == null) throw new ArgumentNullException(nameof(cancellationToken));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
 
             // Let's call a web api service to make repeated requests to a server. 

--- a/PollyDemos/Async/AsyncDemo08_Wrap-Fallback-WaitAndRetry-CircuitBreaker.cs
+++ b/PollyDemos/Async/AsyncDemo08_Wrap-Fallback-WaitAndRetry-CircuitBreaker.cs
@@ -37,7 +37,6 @@ namespace PollyDemos.Async
 
         public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (cancellationToken == null) throw new ArgumentNullException(nameof(cancellationToken));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
 
             // Let's call a web api service to make repeated requests to a server. 

--- a/PollyDemos/Async/AsyncDemo09_Wrap-Fallback-Timeout-WaitAndRetry.cs
+++ b/PollyDemos/Async/AsyncDemo09_Wrap-Fallback-Timeout-WaitAndRetry.cs
@@ -38,7 +38,6 @@ namespace PollyDemos.Async
 
         public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (cancellationToken == null) throw new ArgumentNullException(nameof(cancellationToken));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
 
             // Let's call a web api service to make repeated requests to a server. 

--- a/PollyDemos/Async/BulkheadAsyncDemo00_NoIsolation.cs
+++ b/PollyDemos/Async/BulkheadAsyncDemo00_NoIsolation.cs
@@ -45,7 +45,6 @@ namespace PollyDemos.Async
         public override async Task ExecuteAsync(CancellationToken externalCancellationToken,
             IProgress<DemoProgress> progress)
         {
-            if (externalCancellationToken == null) throw new ArgumentNullException(nameof(externalCancellationToken));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
 
             progress.Report(ProgressWithMessage(typeof(BulkheadAsyncDemo00_NoIsolation).Name));

--- a/PollyDemos/Async/BulkheadAsyncDemo01_WithBulkheads.cs
+++ b/PollyDemos/Async/BulkheadAsyncDemo01_WithBulkheads.cs
@@ -47,7 +47,6 @@ namespace PollyDemos.Async
         public override async Task ExecuteAsync(CancellationToken externalCancellationToken,
             IProgress<DemoProgress> progress)
         {
-            if (externalCancellationToken == null) throw new ArgumentNullException(nameof(externalCancellationToken));
             if (progress == null) throw new ArgumentNullException(nameof(progress));
 
             progress.Report(ProgressWithMessage(typeof(BulkheadAsyncDemo01_WithBulkheads).Name));


### PR DESCRIPTION
Removing unnecessary null validation for CancellationToken - solves #26 