### PR TITLE
Fix broken TFMs

### DIFF
--- a/PollyTestClientConsole/PollyTestClientConsole.csproj
+++ b/PollyTestClientConsole/PollyTestClientConsole.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net60</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/PollyTestClientWpf/PollyTestClientWpf.csproj
+++ b/PollyTestClientWpf/PollyTestClientWpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net60-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>

--- a/PollyTestWebApi/PollyTestWebApi.csproj
+++ b/PollyTestWebApi/PollyTestWebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net60</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix broken TFMs so `dotnet build` in the repo root doesn't fail.
