### PR TITLE
Migrate sync demos from 04 to 06

### DIFF
--- a/PollyDemos/Sync/Demo00_NoStrategy.cs
+++ b/PollyDemos/Sync/Demo00_NoStrategy.cs
@@ -4,7 +4,7 @@ namespace PollyDemos.Sync
 {
     /// <summary>
     /// Uses no strategy.  Demonstrates behavior of 'faulting server' we are testing against.
-    /// Loops through a series of Http requests, keeping track of each requested
+    /// Loops through a series of HTTP requests, keeping track of each requested
     /// item and reporting server failures when encountering exceptions.
     /// </summary>
     public class Demo00_NoStrategy : SyncDemo
@@ -20,7 +20,7 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web api service to make repeated requests to a server.
+            // Let's call a web API service to make repeated requests to a server.
             // The service is programmed to fail after 3 requests in 5 seconds.
 
             eventualSuccesses = 0;

--- a/PollyDemos/Sync/Demo01_RetryNTimes.cs
+++ b/PollyDemos/Sync/Demo01_RetryNTimes.cs
@@ -51,7 +51,7 @@ namespace PollyDemos.Sync
                     var exception = args.Outcome.Exception!; //The Exception property is nullable
 
                     // Tell the user what happened
-                    progress.Report(ProgressWithMessage("Strategy logging: " + exception.Message, Color.Yellow));
+                    progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
                     retries++;
                     return default;
                 }

--- a/PollyDemos/Sync/Demo01_RetryNTimes.cs
+++ b/PollyDemos/Sync/Demo01_RetryNTimes.cs
@@ -4,7 +4,7 @@ namespace PollyDemos.Sync
 {
     /// <summary>
     /// Demonstrates the Retry strategy coming into action.
-    /// Loops through a series of Http requests, keeping track of each requested
+    /// Loops through a series of HTTP requests, keeping track of each requested
     /// item and reporting server failures when encountering exceptions.
     ///
     /// Observations: There's no wait among these retries.  Can be appropriate sometimes.
@@ -24,7 +24,7 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web api service to make repeated requests to a server.
+            // Let's call a web API service to make repeated requests to a server.
             // The service is programmed to fail after 3 requests in 5 seconds.
 
             eventualSuccesses = 0;
@@ -35,9 +35,6 @@ namespace PollyDemos.Sync
             progress.Report(ProgressWithMessage(nameof(Demo01_RetryNTimes)));
             progress.Report(ProgressWithMessage("======"));
             progress.Report(ProgressWithMessage(string.Empty));
-
-            // Let's call a web api service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
 
             // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()

--- a/PollyDemos/Sync/Demo02_WaitAndRetryNTimes.cs
+++ b/PollyDemos/Sync/Demo02_WaitAndRetryNTimes.cs
@@ -53,7 +53,7 @@ namespace PollyDemos.Sync
                     var exception = args.Outcome.Exception!; //The Exception property is nullable
 
                     // Tell the user what happened
-                    progress.Report(ProgressWithMessage("Strategy logging: " + exception.Message, Color.Yellow));
+                    progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
                     retries++;
                     return default;
                 }

--- a/PollyDemos/Sync/Demo02_WaitAndRetryNTimes.cs
+++ b/PollyDemos/Sync/Demo02_WaitAndRetryNTimes.cs
@@ -4,7 +4,7 @@ namespace PollyDemos.Sync
 {
     /// <summary>
     /// Demonstrates the Retry strategy with delays between retry attempts.
-    /// Loops through a series of Http requests, keeping track of each requested
+    /// Loops through a series of HTTP requests, keeping track of each requested
     /// item and reporting server failures when encountering exceptions.
     ///
     /// Observations: We now have waits among the retries.
@@ -25,7 +25,7 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web api service to make repeated requests to a server.
+            // Let's call a web API service to make repeated requests to a server.
             // The service is programmed to fail after 3 requests in 5 seconds.
 
             eventualSuccesses = 0;
@@ -36,9 +36,6 @@ namespace PollyDemos.Sync
             progress.Report(ProgressWithMessage(nameof(Demo02_WaitAndRetryNTimes)));
             progress.Report(ProgressWithMessage("======"));
             progress.Report(ProgressWithMessage(string.Empty));
-
-            // Let's call a web api service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
 
             // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()

--- a/PollyDemos/Sync/Demo03_WaitAndRetryNTimes_WithEnoughRetries.cs
+++ b/PollyDemos/Sync/Demo03_WaitAndRetryNTimes_WithEnoughRetries.cs
@@ -53,7 +53,7 @@ namespace PollyDemos.Sync
                     var exception = args.Outcome.Exception!; //The Exception property is nullable
 
                     // Tell the user what happened
-                    progress.Report(ProgressWithMessage("Strategy logging: " + exception.Message, Color.Yellow));
+                    progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
                     retries++;
                     return default;
                 }

--- a/PollyDemos/Sync/Demo03_WaitAndRetryNTimes_WithEnoughRetries.cs
+++ b/PollyDemos/Sync/Demo03_WaitAndRetryNTimes_WithEnoughRetries.cs
@@ -4,7 +4,7 @@ namespace PollyDemos.Sync
 {
     /// <summary>
     /// Demonstrates the Retry strategy with delays between retry attempts.
-    /// Loops through a series of Http requests, keeping track of each requested
+    /// Loops through a series of HTTP requests, keeping track of each requested
     /// item and reporting server failures when encountering exceptions.
     ///
     /// Observations: We now have waits and enough retries: all calls now succeed!  Yay!
@@ -25,7 +25,7 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web api service to make repeated requests to a server.
+            // Let's call a web API service to make repeated requests to a server.
             // The service is programmed to fail after 3 requests in 5 seconds.
 
             eventualSuccesses = 0;
@@ -36,9 +36,6 @@ namespace PollyDemos.Sync
             progress.Report(ProgressWithMessage(nameof(Demo03_WaitAndRetryNTimes_WithEnoughRetries)));
             progress.Report(ProgressWithMessage("======"));
             progress.Report(ProgressWithMessage(string.Empty));
-
-            // Let's call a web api service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
 
             // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()

--- a/PollyDemos/Sync/Demo04_WaitAndRetryForever.cs
+++ b/PollyDemos/Sync/Demo04_WaitAndRetryForever.cs
@@ -1,16 +1,15 @@
-﻿using System.Net;
-using PollyDemos.OutputHelpers;
+﻿using PollyDemos.OutputHelpers;
 
 namespace PollyDemos.Sync
 {
     /// <summary>
-    /// Demonstrates the WaitAndRetryForever policy.
+    /// Demonstrates the Retry strategy with delays between retry attempts.
     /// Loops through a series of Http requests, keeping track of each requested
     /// item and reporting server failures when encountering exceptions.
-    /// 
-    /// Observations: We no longer have to guess how many retries are enough.  
+    ///
+    /// Observations: We no longer have to guess how many retries are enough.
     /// All calls still succeed!  Yay!
-    /// But we're still hammering that underlying server with retries. 
+    /// But we're still hammering that underlying server with retries.
     /// Imagine if lots of clients were doing that simultaneously
     ///  - could just increase load on an already-struggling server!
     /// </summary>
@@ -26,82 +25,86 @@ namespace PollyDemos.Sync
 
         public override void Execute(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (progress == null) throw new ArgumentNullException(nameof(progress));
+            ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web api service to make repeated requests to a server. 
+            // Let's call a web api service to make repeated requests to a server.
             // The service is programmed to fail after 3 requests in 5 seconds.
 
             eventualSuccesses = 0;
             retries = 0;
             eventualFailures = 0;
+            totalRequests = 0;
 
             progress.Report(ProgressWithMessage(nameof(Demo04_WaitAndRetryForever)));
             progress.Report(ProgressWithMessage("======"));
             progress.Report(ProgressWithMessage(string.Empty));
 
-            // Let's call a web api service to make repeated requests to a server. 
+            // Let's call a web api service to make repeated requests to a server.
             // The service is programmed to fail after 3 requests in 5 seconds.
 
-            // Define our policy:
-            var policy = Policy.Handle<Exception>().WaitAndRetryForever(
-                attempt => TimeSpan.FromMilliseconds(200), // Wait 200ms between each try.
-                (exception, calculatedWaitDuration) => // Capture some info for logging!
-                {
-                    // This is your new exception handler! 
-                    // Tell the user what they've won!
-                    progress.Report(ProgressWithMessage("Log, then retry: " + exception.Message, Color.Yellow));
-                    retries++;
-                });
-
-            using (var client = new WebClient())
+            // Define our strategy:
+            var strategy = new ResiliencePipelineBuilder().AddRetry(new()
             {
-                var internalCancel = false;
-                totalRequests = 0;
-                // Do the following until a key is pressed
-                while (!internalCancel && !cancellationToken.IsCancellationRequested)
+                ShouldHandle = new PredicateBuilder().Handle<Exception>(),
+                MaxRetryAttempts = int.MaxValue, // Retry indefinitely
+                Delay = TimeSpan.FromMilliseconds(200),  // Wait 200ms between each try
+                OnRetry = args =>
                 {
-                    totalRequests++;
+                    // Due to how we have defined ShouldHandle, this delegate is called only if an exception occurred.
+                    // Note the ! sign (null-forgiving operator) at the end of the command.
+                    var exception = args.Outcome.Exception!; //The Exception property is nullable
 
-                    try
-                    {
-                        // Retry the following call according to the policy - 15 times.
-                        policy.Execute(
-                            ct => // The Execute() overload takes a CancellationToken, but it happens the executed code does not honour it.
-                            {
-                                // This code is executed within the Policy 
-
-                                // Make a request and get a response
-                                var msg = client.DownloadString(
-                                    Configuration.WEB_API_ROOT + "/api/values/" + totalRequests.ToString());
-
-                                // Display the response message on the console
-                                progress.Report(ProgressWithMessage("Response : " + msg, Color.Green));
-                                eventualSuccesses++;
-                            }
-                            , cancellationToken // The cancellationToken passed in to Execute() enables the policy instance to cancel retries, when the token is signalled.
-                        );
-                    }
-                    catch (Exception e)
-                    {
-                        progress.Report(ProgressWithMessage(
-                            "Request " + totalRequests + " eventually failed with: " + e.Message, Color.Red));
-                        eventualFailures++;
-                    }
-
-                    // Wait half second before the next request.
-                    Thread.Sleep(500);
-
-                    internalCancel = TerminateDemosByKeyPress && Console.KeyAvailable;
+                    // Tell the user what happened
+                    progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
+                    retries++;
+                    return default;
                 }
+            }).Build();
+
+            var client = new HttpClient();
+            var internalCancel = false;
+
+            // Do the following until a key is pressed
+            while (!(internalCancel || cancellationToken.IsCancellationRequested))
+            {
+                totalRequests++;
+
+                try
+                {
+                    // Retry the following call according to the strategy.
+                    // The cancellationToken passed in to Execute() enables the strategy to cancel retries, when the token is signalled.
+                    strategy.Execute(ct =>
+                    {
+                        // This code is executed within the strategy
+
+                        // Make a request and get a response
+                        var url = $"{Configuration.WEB_API_ROOT}/api/values/{totalRequests}";
+                        var response = client.Send(new HttpRequestMessage(HttpMethod.Get, url), ct);
+
+                        // Display the response message on the console
+                        using var stream = response.Content.ReadAsStream(ct);
+                        using var streamReader = new StreamReader(stream);
+                        progress.Report(ProgressWithMessage($"Response : {streamReader.ReadToEnd()}", Color.Green));
+                        eventualSuccesses++;
+                    }, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
+                    eventualFailures++;
+                }
+
+                Thread.Sleep(500);
+                internalCancel = TerminateDemosByKeyPress && Console.KeyAvailable;
             }
         }
 
-        public override Statistic[] LatestStatistics => new[]
+        public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new Statistic("Total requests made", totalRequests),
-            new Statistic("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new Statistic("Retries made to help achieve success", retries, Color.Yellow),
-            new Statistic("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Total requests made", totalRequests),
+            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", retries, Color.Yellow),
+            new("Requests which eventually failed", eventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Sync/Demo04_WaitAndRetryForever.cs
+++ b/PollyDemos/Sync/Demo04_WaitAndRetryForever.cs
@@ -4,7 +4,7 @@ namespace PollyDemos.Sync
 {
     /// <summary>
     /// Demonstrates the Retry strategy with delays between retry attempts.
-    /// Loops through a series of Http requests, keeping track of each requested
+    /// Loops through a series of HTTP requests, keeping track of each requested
     /// item and reporting server failures when encountering exceptions.
     ///
     /// Observations: We no longer have to guess how many retries are enough.
@@ -27,7 +27,7 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web api service to make repeated requests to a server.
+            // Let's call a web API service to make repeated requests to a server.
             // The service is programmed to fail after 3 requests in 5 seconds.
 
             eventualSuccesses = 0;
@@ -38,9 +38,6 @@ namespace PollyDemos.Sync
             progress.Report(ProgressWithMessage(nameof(Demo04_WaitAndRetryForever)));
             progress.Report(ProgressWithMessage("======"));
             progress.Report(ProgressWithMessage(string.Empty));
-
-            // Let's call a web api service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
 
             // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()

--- a/PollyDemos/Sync/Demo05_WaitAndRetryWithExponentialBackoff.cs
+++ b/PollyDemos/Sync/Demo05_WaitAndRetryWithExponentialBackoff.cs
@@ -1,19 +1,18 @@
-﻿using System.Net;
-using PollyDemos.OutputHelpers;
+﻿using PollyDemos.OutputHelpers;
 
 namespace PollyDemos.Sync
 {
     /// <summary>
-    /// Demonstrates WaitAndRetry policy with calculated retry delays to back off.
+    /// Demonstrates Retry strategy with calculated retry delays to back off.
     /// Loops through a series of Http requests, keeping track of each requested
     /// item and reporting server failures when encountering exceptions.
-    /// 
+    ///
     /// Observations: All calls still succeed!  Yay!
     /// But we didn't hammer the underlying server so hard - we backed off.
     /// That's healthier for it, if it might be struggling ...
     /// ... and if a lot of clients might be doing this simultaneously.
-    /// 
-    /// ... What if the underlying system was totally down tho?  
+    ///
+    /// ... What if the underlying system was totally down tho?
     /// ... Keeping trying forever would be counterproductive (so, see Demo06)
     /// </summary>
     public class Demo05_WaitAndRetryWithExponentialBackoff : SyncDemo
@@ -28,83 +27,84 @@ namespace PollyDemos.Sync
 
         public override void Execute(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (progress == null) throw new ArgumentNullException(nameof(progress));
+            ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web api service to make repeated requests to a server. 
+            // Let's call a web api service to make repeated requests to a server.
             // The service is programmed to fail after 3 requests in 5 seconds.
 
             eventualSuccesses = 0;
             retries = 0;
             eventualFailures = 0;
+            totalRequests = 0;
 
             progress.Report(ProgressWithMessage(nameof(Demo05_WaitAndRetryWithExponentialBackoff)));
             progress.Report(ProgressWithMessage("======"));
             progress.Report(ProgressWithMessage(string.Empty));
 
-            var policy = Policy.Handle<Exception>()
-                .WaitAndRetry(6, // We can also do this with WaitAndRetryForever... but chose WaitAndRetry this time.
-                    attempt => TimeSpan.FromSeconds(0.1 * Math.Pow(2,
-                                                        attempt)), // Back off!  2, 4, 8, 16 etc times 1/4-second
-                    (exception, calculatedWaitDuration) => // Capture some info for logging!
-                    {
-                        // This is your new exception handler! 
-                        // Tell the user what they've won!
-                        progress.Report(ProgressWithMessage("Exception: " + exception.Message, Color.Yellow));
-                        progress.Report(ProgressWithMessage(
-                            " ... automatically delaying for " + calculatedWaitDuration.TotalMilliseconds + "ms.",
-                            Color.Yellow));
-                        retries++;
-                    });
-
-            using (var client = new WebClient())
+            // Define our strategy:
+            var strategy = new ResiliencePipelineBuilder().AddRetry(new()
             {
-                var internalCancel = false;
-                totalRequests = 0;
-                // Do the following until a key is pressed
-                while (!internalCancel && !cancellationToken.IsCancellationRequested)
+                ShouldHandle = new PredicateBuilder().Handle<Exception>(),
+                MaxRetryAttempts = 6, // We could also retry indefinitely... but chose six times instead.
+                BackoffType = DelayBackoffType.Exponential,
+                OnRetry = args =>
                 {
-                    totalRequests++;
+                    // Due to how we have defined ShouldHandle, this delegate is called only if an exception occurred.
+                    // Note the ! sign (null-forgiving operator) at the end of the command.
+                    var exception = args.Outcome.Exception!; //The Exception property is nullable
 
-                    try
-                    {
-                        // Retry the following call according to the policy - 15 times.
-                        policy.Execute(
-                            ct => // The Execute() overload takes a CancellationToken, but it happens the executed code does not honour it.
-                            {
-                                // This code is executed within the Policy 
-
-                                // Make a request and get a response
-                                var msg = client.DownloadString(
-                                    Configuration.WEB_API_ROOT + "/api/values/" + totalRequests);
-
-                                // Display the response message on the console
-                                progress.Report(ProgressWithMessage("Response : " + msg, Color.Green));
-                                eventualSuccesses++;
-                            }
-                            , cancellationToken // The cancellationToken passed in to Execute() enables the policy instance to cancel retries, when the token is signalled.
-                        );
-                    }
-                    catch (Exception e)
-                    {
-                        progress.Report(ProgressWithMessage(
-                            "Request " + totalRequests + " eventually failed with: " + e.Message, Color.Red));
-                        eventualFailures++;
-                    }
-
-                    // Wait half second before the next request.
-                    Thread.Sleep(500);
-
-                    internalCancel = TerminateDemosByKeyPress && Console.KeyAvailable;
+                    // Tell the user what happened
+                    progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
+                    progress.Report(ProgressWithMessage($" ... automatically delaying for {args.RetryDelay.TotalMilliseconds}ms.", Color.Yellow));
+                    retries++;
+                    return default;
                 }
+            }).Build();
+
+            var client = new HttpClient();
+            var internalCancel = false;
+
+            // Do the following until a key is pressed
+            while (!(internalCancel || cancellationToken.IsCancellationRequested))
+            {
+                totalRequests++;
+
+                try
+                {
+                    // Retry the following call according to the strategy.
+                    // The cancellationToken passed in to Execute() enables the strategy to cancel retries, when the token is signalled.
+                    strategy.Execute(ct =>
+                    {
+                        // This code is executed within the strategy
+
+                        // Make a request and get a response
+                        var url = $"{Configuration.WEB_API_ROOT}/api/values/{totalRequests}";
+                        var response = client.Send(new HttpRequestMessage(HttpMethod.Get, url), ct);
+
+                        // Display the response message on the console
+                        using var stream = response.Content.ReadAsStream(ct);
+                        using var streamReader = new StreamReader(stream);
+                        progress.Report(ProgressWithMessage($"Response : {streamReader.ReadToEnd()}", Color.Green));
+                        eventualSuccesses++;
+                    }, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
+                    eventualFailures++;
+                }
+
+                Thread.Sleep(500);
+                internalCancel = TerminateDemosByKeyPress && Console.KeyAvailable;
             }
         }
 
-        public override Statistic[] LatestStatistics => new[]
+        public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new Statistic("Total requests made", totalRequests),
-            new Statistic("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new Statistic("Retries made to help achieve success", retries, Color.Yellow),
-            new Statistic("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Total requests made", totalRequests),
+            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", retries, Color.Yellow),
+            new("Requests which eventually failed", eventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Sync/Demo05_WaitAndRetryWithExponentialBackoff.cs
+++ b/PollyDemos/Sync/Demo05_WaitAndRetryWithExponentialBackoff.cs
@@ -4,7 +4,7 @@ namespace PollyDemos.Sync
 {
     /// <summary>
     /// Demonstrates Retry strategy with calculated retry delays to back off.
-    /// Loops through a series of Http requests, keeping track of each requested
+    /// Loops through a series of HTTP requests, keeping track of each requested
     /// item and reporting server failures when encountering exceptions.
     ///
     /// Observations: All calls still succeed!  Yay!
@@ -29,7 +29,7 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web api service to make repeated requests to a server.
+            // Let's call a web API service to make repeated requests to a server.
             // The service is programmed to fail after 3 requests in 5 seconds.
 
             eventualSuccesses = 0;

--- a/PollyDemos/Sync/Demo06_WaitAndRetryNestingCircuitBreaker.cs
+++ b/PollyDemos/Sync/Demo06_WaitAndRetryNestingCircuitBreaker.cs
@@ -6,7 +6,7 @@ namespace PollyDemos.Sync
 {
     /// <summary>
     /// Demonstrates using the Retry strategy nesting CircuitBreaker.
-    /// Loops through a series of Http requests, keeping track of each requested
+    /// Loops through a series of HTTP requests, keeping track of each requested
     /// item and reporting server failures when encountering exceptions.
     ///
     /// Discussion:  What if the underlying system was completely down?
@@ -16,7 +16,7 @@ namespace PollyDemos.Sync
     /// Enter circuit-breaker:
     /// After too many failures, breaks the circuit for a period, during which it blocks calls + fails fast.
     /// - protects the downstream system from too many calls if it's really struggling (reduces load, so it can recover)
-    /// - allows the client to get a fail response _fast, not wait for ages, if downstream is awol.
+    /// - allows the client to get a fail response fast, not wait for ages, if downstream is AWOL.
     ///
     /// Observations:
     /// Note how after the circuit decides to break, subsequent calls fail faster.
@@ -38,7 +38,7 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web api service to make repeated requests to a server.
+            // Let's call a web API service to make repeated requests to a server.
             // The service is programmed to fail after 3 requests in 5 seconds.
 
             eventualSuccesses = 0;
@@ -54,7 +54,7 @@ namespace PollyDemos.Sync
             // Define our retry strategy:
             var retryStrategy = new ResiliencePipelineBuilder().AddRetry(new()
             {
-                // Exception filtering!  We don't retry if the inner circuit-breaker judges the underlying system is out of commission.
+                // Exception filtering - we don't retry if the inner circuit-breaker judges the underlying system is out of commission.
                 ShouldHandle = new PredicateBuilder().Handle<Exception>(ex => ex is not BrokenCircuitException),
                 MaxRetryAttempts = int.MaxValue, // Retry indefinitely
                 Delay = TimeSpan.FromMilliseconds(200),  // Wait 200ms between each try
@@ -71,7 +71,7 @@ namespace PollyDemos.Sync
                 }
             }).Build();
 
-            // Define our circuit breaker strategy: Break if the action fails 4 times in a row.
+            // Define our circuit breaker strategy: break if the action fails 4 times in a row.
             var circuitBreakerStrategy = new ResiliencePipelineBuilder().AddCircuitBreaker(new()
             {
                 ShouldHandle = new PredicateBuilder().Handle<Exception>(),
@@ -92,7 +92,7 @@ namespace PollyDemos.Sync
                 },
                 OnClosed = args =>
                 {
-                    progress.Report(ProgressWithMessage(".Breaker logging: Call ok! Closed the circuit again!", Color.Magenta));
+                    progress.Report(ProgressWithMessage(".Breaker logging: Call OK! Closed the circuit again!", Color.Magenta));
                     return default;
                 },
                 OnHalfOpened = args =>

--- a/PollyDemos/Sync/Demo06_WaitAndRetryNestingCircuitBreaker.cs
+++ b/PollyDemos/Sync/Demo06_WaitAndRetryNestingCircuitBreaker.cs
@@ -1,25 +1,24 @@
 ﻿using System.Diagnostics;
-using System.Net;
 using Polly.CircuitBreaker;
 using PollyDemos.OutputHelpers;
 
 namespace PollyDemos.Sync
 {
     /// <summary>
-    /// Demonstrates using the WaitAndRetry policy nesting CircuitBreaker.
+    /// Demonstrates using the Retry strategy nesting CircuitBreaker.
     /// Loops through a series of Http requests, keeping track of each requested
     /// item and reporting server failures when encountering exceptions.
-    /// 
-    /// Discussion:  What if the underlying system was completely down?  
+    ///
+    /// Discussion:  What if the underlying system was completely down?
     /// Keeping retrying would be pointless...
     /// ... and would leave the client hanging, retrying for successes which never come.
-    /// 
-    /// Enter circuit-breaker: 
+    ///
+    /// Enter circuit-breaker:
     /// After too many failures, breaks the circuit for a period, during which it blocks calls + fails fast.
     /// - protects the downstream system from too many calls if it's really struggling (reduces load, so it can recover)
     /// - allows the client to get a fail response _fast, not wait for ages, if downstream is awol.
-    /// 
-    /// Obervations from this demo:
+    ///
+    /// Observations:
     /// Note how after the circuit decides to break, subsequent calls fail faster.
     /// Note how breaker gives underlying system time to recover ...
     /// ... by the time circuit closes again, underlying system has recovered!
@@ -37,135 +36,136 @@ namespace PollyDemos.Sync
 
         public override void Execute(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
-            if (progress == null) throw new ArgumentNullException(nameof(progress));
+            ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web api service to make repeated requests to a server. 
+            // Let's call a web api service to make repeated requests to a server.
             // The service is programmed to fail after 3 requests in 5 seconds.
 
             eventualSuccesses = 0;
             retries = 0;
             eventualFailuresDueToCircuitBreaking = 0;
             eventualFailuresForOtherReasons = 0;
+            totalRequests = 0;
 
             progress.Report(ProgressWithMessage(nameof(Demo06_WaitAndRetryNestingCircuitBreaker)));
             progress.Report(ProgressWithMessage("======"));
             progress.Report(ProgressWithMessage(string.Empty));
 
-            // Define our waitAndRetry policy: keep retrying with 200ms gaps.
-            var waitAndRetryPolicy = Policy
-                .Handle<Exception
-                >(e =>
-                    !(e is BrokenCircuitException)) // Exception filtering!  We don't retry if the inner circuit-breaker judges the underlying system is out of commission!
-                .WaitAndRetryForever(
-                    attempt => TimeSpan.FromMilliseconds(200),
-                    (exception, calculatedWaitDuration) =>
-                    {
-                        // This is your new exception handler! 
-                        // Tell the user what they've won!
-                        progress.Report(ProgressWithMessage(".Log,then retry: " + exception.Message, Color.Yellow));
-                        retries++;
-                    });
-
-            // Define our CircuitBreaker policy: Break if the action fails 4 times in a row.
-            var circuitBreakerPolicy = Policy
-                .Handle<Exception>()
-                .CircuitBreaker(
-                    4,
-                    TimeSpan.FromSeconds(3),
-                    (ex, breakDelay) =>
-                    {
-                        progress.Report(ProgressWithMessage(
-                            ".Breaker logging: Breaking the circuit for " + breakDelay.TotalMilliseconds + "ms!",
-                            Color.Magenta));
-                        progress.Report(ProgressWithMessage("..due to: " + ex.Message, Color.Magenta));
-                    },
-                    () => progress.Report(ProgressWithMessage(".Breaker logging: Call ok! Closed the circuit again!",
-                        Color.Magenta)),
-                    () => progress.Report(ProgressWithMessage(".Breaker logging: Half-open: Next call is a trial!",
-                        Color.Magenta))
-                );
-
-            using (var client = new WebClient())
+            // Define our retry strategy:
+            var retryStrategy = new ResiliencePipelineBuilder().AddRetry(new()
             {
-                var internalCancel = false;
-                totalRequests = 0;
-                // Do the following until a key is pressed
-                while (!internalCancel && !cancellationToken.IsCancellationRequested)
+                // Exception filtering!  We don't retry if the inner circuit-breaker judges the underlying system is out of commission.
+                ShouldHandle = new PredicateBuilder().Handle<Exception>(ex => ex is not BrokenCircuitException),
+                MaxRetryAttempts = int.MaxValue, // Retry indefinitely
+                Delay = TimeSpan.FromMilliseconds(200),  // Wait 200ms between each try
+                OnRetry = args =>
                 {
-                    totalRequests++;
-                    var watch = new Stopwatch();
-                    watch.Start();
+                    // Due to how we have defined ShouldHandle, this delegate is called only if an exception occurred.
+                    // Note the ! sign (null-forgiving operator) at the end of the command.
+                    var exception = args.Outcome.Exception!; //The Exception property is nullable
 
-                    try
-                    {
-                        // Retry the following call according to the policy - 3 times.
-                        waitAndRetryPolicy.Execute(
-                            ct => // The Execute() overload takes a CancellationToken, but it happens the executed code does not honour it.
-                            {
-                                // This code is executed within the waitAndRetryPolicy 
-
-                                var response = circuitBreakerPolicy.Execute<string>(
-                                    () => // Note how we can also Execute() a Func<TResult> and pass back the value.
-                                    {
-                                        // This code is executed within the circuitBreakerPolicy 
-
-                                        // Make a request and get a response
-                                        return client.DownloadString(
-                                            Configuration.WEB_API_ROOT + "/api/values/" + totalRequests);
-                                    });
-
-                                watch.Stop();
-
-                                // Display the response message on the console
-                                progress.Report(ProgressWithMessage("Response : " + response
-                                                                                  + " (after " +
-                                                                                  watch.ElapsedMilliseconds + "ms)",
-                                    Color.Green));
-
-                                eventualSuccesses++;
-                            }
-                            , cancellationToken // The cancellationToken passed in to Execute() enables the policy instance to cancel retries, when the token is signalled.
-                        );
-                    }
-                    catch (BrokenCircuitException b)
-                    {
-                        watch.Stop();
-
-                        progress.Report(ProgressWithMessage("Request " + totalRequests + " failed with: " +
-                                                            b.GetType().Name
-                                                            + " (after " + watch.ElapsedMilliseconds + "ms)",
-                            Color.Red));
-
-                        eventualFailuresDueToCircuitBreaking++;
-                    }
-                    catch (Exception e)
-                    {
-                        watch.Stop();
-
-                        progress.Report(ProgressWithMessage("Request " + totalRequests + " eventually failed with: " +
-                                                            e.Message
-                                                            + " (after " + watch.ElapsedMilliseconds + "ms)",
-                            Color.Red));
-
-                        eventualFailuresForOtherReasons++;
-                    }
-
-                    // Wait half second
-                    Thread.Sleep(500);
-
-                    internalCancel = TerminateDemosByKeyPress && Console.KeyAvailable;
+                    // Tell the user what happened
+                    progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
+                    retries++;
+                    return default;
                 }
+            }).Build();
+
+            // Define our circuit breaker strategy: Break if the action fails 4 times in a row.
+            var circuitBreakerStrategy = new ResiliencePipelineBuilder().AddCircuitBreaker(new()
+            {
+                ShouldHandle = new PredicateBuilder().Handle<Exception>(),
+                FailureRatio = 1.0,
+                MinimumThroughput = 4,
+                BreakDuration = TimeSpan.FromSeconds(3),
+                OnOpened = args =>
+                {
+                    progress.Report(ProgressWithMessage(
+                            $".Breaker logging: Breaking the circuit for {args.BreakDuration.TotalMilliseconds}ms!",
+                            Color.Magenta));
+
+                    // Due to how we have defined ShouldHandle, this delegate is called only if an exception occurred.
+                    // Note the ! sign (null-forgiving operator) at the end of the command.
+                    var exception = args.Outcome.Exception!; //The Exception property is nullable
+                    progress.Report(ProgressWithMessage($"..due to: {exception.Message}", Color.Magenta));
+                    return default;
+                },
+                OnClosed = args =>
+                {
+                    progress.Report(ProgressWithMessage(".Breaker logging: Call ok! Closed the circuit again!", Color.Magenta));
+                    return default;
+                },
+                OnHalfOpened = args =>
+                {
+                    progress.Report(ProgressWithMessage(".Breaker logging: Half-open: Next call is a trial!", Color.Magenta));
+                    return default;
+                }
+            }).Build();
+
+            var client = new HttpClient();
+            var internalCancel = false;
+
+            // Do the following until a key is pressed
+            while (!(internalCancel || cancellationToken.IsCancellationRequested))
+            {
+                totalRequests++;
+                var watch = Stopwatch.StartNew();
+
+                try
+                {
+                    // Retry the following call according to the strategy.
+                    retryStrategy.Execute(ct =>
+                    {
+                        // This code is executed within the retry strategy.
+
+                        // Note how we can also Execute() a Func<TResult> and pass back the value.
+                        var response = circuitBreakerStrategy.Execute(innerCt =>
+                        {
+                            // This code is executed within the circuit breaker strategy.
+
+                            // Make a request and get a response
+                            var url = $"{Configuration.WEB_API_ROOT}/api/values/{totalRequests}";
+                            var response = client.Send(new HttpRequestMessage(HttpMethod.Get, url), innerCt);
+
+                            using var stream = response.Content.ReadAsStream(innerCt);
+                            using var streamReader = new StreamReader(stream);
+                            return streamReader.ReadToEnd();
+                        }, ct);
+
+                        watch.Stop();
+
+                        // Display the response message on the console
+                        progress.Report(ProgressWithMessage($"Response : {response} (after {watch.ElapsedMilliseconds}ms)", Color.Green));
+                        eventualSuccesses++;
+                    }, cancellationToken);
+                }
+                catch (BrokenCircuitException bce)
+                {
+                    watch.Stop();
+                    var logMessage = $"Request {totalRequests} failed with: {bce.GetType().Name} (after {watch.ElapsedMilliseconds}ms)";
+                    progress.Report(ProgressWithMessage(logMessage,Color.Red));
+                    eventualFailuresDueToCircuitBreaking++;
+                }
+                catch (Exception e)
+                {
+                    watch.Stop();
+                    var logMessage = $"Request {totalRequests} eventually failed with: {e.Message} (after {watch.ElapsedMilliseconds}ms)";
+                    progress.Report(ProgressWithMessage(logMessage,Color.Red));
+                    eventualFailuresForOtherReasons++;
+                }
+
+                Thread.Sleep(500);
+                internalCancel = TerminateDemosByKeyPress && Console.KeyAvailable;
             }
         }
 
-        public override Statistic[] LatestStatistics => new[]
+        public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new Statistic("Total requests made", totalRequests),
-            new Statistic("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new Statistic("Retries made to help achieve success", retries, Color.Yellow),
-            new Statistic("Requests failed early by broken circuit", eventualFailuresDueToCircuitBreaking,
-                Color.Magenta),
-            new Statistic("Requests which failed after longer delay", eventualFailuresForOtherReasons, Color.Red),
+            new("Total requests made", totalRequests),
+            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", retries, Color.Yellow),
+            new("Requests failed early by broken circuit", eventualFailuresDueToCircuitBreaking, Color.Magenta),
+            new("Requests which failed after longer delay", eventualFailuresForOtherReasons, Color.Red),
         };
     }
 }


### PR DESCRIPTION
## Description:
- Replaced string concatenation to string interpolation  demo 1, 2, and 3
- Migrated form Demo04 to Demo06 under Sync folder to use `HttpClient` instead of `WebClient`
- Migrated policies to strategies 

