### PR TITLE
Simplify sync demos by extracting common parts

### DIFF
--- a/PollyDemos/DemoBase.cs
+++ b/PollyDemos/DemoBase.cs
@@ -18,5 +18,12 @@ namespace PollyDemos
 
         public DemoProgress ProgressWithMessages(IEnumerable<ColoredMessage> messages)
             => new (LatestStatistics, messages);
+
+        public void PrintHeader(IProgress<DemoProgress> progress, string demoName)
+        {
+            progress.Report(ProgressWithMessage(demoName));
+            progress.Report(ProgressWithMessage("======"));
+            progress.Report(ProgressWithMessage(string.Empty));
+        }
     }
 }

--- a/PollyDemos/Sync/Demo00_NoStrategy.cs
+++ b/PollyDemos/Sync/Demo00_NoStrategy.cs
@@ -3,16 +3,12 @@
 namespace PollyDemos.Sync
 {
     /// <summary>
-    /// Uses no strategy.  Demonstrates behavior of 'faulting server' we are testing against.
+    /// Uses no strategy. Demonstrates behavior of 'faulting server' we are testing against.
     /// Loops through a series of HTTP requests, keeping track of each requested
     /// item and reporting server failures when encountering exceptions.
     /// </summary>
     public class Demo00_NoStrategy : SyncDemo
     {
-        private int totalRequests;
-        private int eventualSuccesses;
-        private int eventualFailures;
-
         public override string Description =>
             "This demo demonstrates how our faulting server behaves, with no Polly policies in use.";
 
@@ -27,12 +23,11 @@ namespace PollyDemos.Sync
             eventualFailures = 0;
             totalRequests = 0;
 
-            progress.Report(ProgressWithMessage(nameof(Demo00_NoStrategy)));
-            progress.Report(ProgressWithMessage("======"));
-            progress.Report(ProgressWithMessage(string.Empty));
+            PrintHeader(progress, nameof(Demo00_NoStrategy));
 
             var client = new HttpClient();
             var internalCancel = false;
+
             // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
@@ -40,14 +35,8 @@ namespace PollyDemos.Sync
 
                 try
                 {
-                    // Make a request and get a response
-                    var url = $"{Configuration.WEB_API_ROOT}/api/values/{totalRequests}";
-                    var response = client.Send(new HttpRequestMessage(HttpMethod.Get, url));
-
-                    // Display the response message on the console
-                    using var stream = response.Content.ReadAsStream();
-                    using var streamReader = new StreamReader(stream);
-                    progress.Report(ProgressWithMessage($"Response : {streamReader.ReadToEnd()}", Color.Green));
+                    var responseBody = IssueRequestAndProcessResponse(client);
+                    progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
                     eventualSuccesses++;
                 }
                 catch (Exception e)

--- a/PollyDemos/Sync/Demo03_WaitAndRetryNTimes_WithEnoughRetries.cs
+++ b/PollyDemos/Sync/Demo03_WaitAndRetryNTimes_WithEnoughRetries.cs
@@ -13,11 +13,6 @@ namespace PollyDemos.Sync
     /// </summary>
     public class Demo03_WaitAndRetryNTimes_WithEnoughRetries : SyncDemo
     {
-        private int totalRequests;
-        private int eventualSuccesses;
-        private int retries;
-        private int eventualFailures;
-
         public override string Description =>
             "Compared to previous demo, this adds enough waiting and retrying to always ensure success.";
 
@@ -33,9 +28,7 @@ namespace PollyDemos.Sync
             eventualFailures = 0;
             totalRequests = 0;
 
-            progress.Report(ProgressWithMessage(nameof(Demo03_WaitAndRetryNTimes_WithEnoughRetries)));
-            progress.Report(ProgressWithMessage("======"));
-            progress.Report(ProgressWithMessage(string.Empty));
+            PrintHeader(progress, nameof(Demo03_WaitAndRetryNTimes_WithEnoughRetries));
 
             // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()
@@ -47,7 +40,7 @@ namespace PollyDemos.Sync
                 {
                     // Due to how we have defined ShouldHandle, this delegate is called only if an exception occurred.
                     // Note the ! sign (null-forgiving operator) at the end of the command.
-                    var exception = args.Outcome.Exception!; //The Exception property is nullable
+                    var exception = args.Outcome.Exception!; // The Exception property is nullable
 
                     // Tell the user what happened
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
@@ -55,7 +48,6 @@ namespace PollyDemos.Sync
                     return default;
                 }
             }).Build();
-
 
             var client = new HttpClient();
             var internalCancel = false;
@@ -67,21 +59,16 @@ namespace PollyDemos.Sync
 
                 try
                 {
-                    // Retry the following call according to the strategy - 20 times.
+                    // Retry the following call according to the strategy.
                     // The cancellationToken passed in to Execute() enables the strategy to cancel retries, when the token is signalled.
-                    strategy.Execute(ct =>
+                    strategy.Execute(token =>
                     {
                         // This code is executed within the strategy
 
-                        // Make a request and get a response
-                        var url = $"{Configuration.WEB_API_ROOT}/api/values/{totalRequests}";
-                        var response = client.Send(new HttpRequestMessage(HttpMethod.Get, url), ct);
-
-                        // Display the response message on the console
-                        using var stream = response.Content.ReadAsStream(ct);
-                        using var streamReader = new StreamReader(stream);
-                        progress.Report(ProgressWithMessage($"Response : {streamReader.ReadToEnd()}", Color.Green));
+                        var responseBody = IssueRequestAndProcessResponse(client, token);
+                        progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
                         eventualSuccesses++;
+
                     }, cancellationToken);
                 }
                 catch (Exception e)

--- a/PollyDemos/Sync/Demo04_WaitAndRetryForever.cs
+++ b/PollyDemos/Sync/Demo04_WaitAndRetryForever.cs
@@ -15,13 +15,8 @@ namespace PollyDemos.Sync
     /// </summary>
     public class Demo04_WaitAndRetryForever : SyncDemo
     {
-        private int totalRequests;
-        private int eventualSuccesses;
-        private int retries;
-        private int eventualFailures;
-
         public override string Description =>
-            "This demo also retries enough to always ensure success.  But we haven't had to 'guess' how many retries were necessary.  We just said: wait-and-retry-forever.";
+            "This demo also retries enough to always ensure success. But we haven't had to 'guess' how many retries were necessary. We just said: wait-and-retry-forever.";
 
         public override void Execute(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
         {
@@ -35,9 +30,7 @@ namespace PollyDemos.Sync
             eventualFailures = 0;
             totalRequests = 0;
 
-            progress.Report(ProgressWithMessage(nameof(Demo04_WaitAndRetryForever)));
-            progress.Report(ProgressWithMessage("======"));
-            progress.Report(ProgressWithMessage(string.Empty));
+            PrintHeader(progress, nameof(Demo04_WaitAndRetryForever));
 
             // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()
@@ -49,7 +42,7 @@ namespace PollyDemos.Sync
                 {
                     // Due to how we have defined ShouldHandle, this delegate is called only if an exception occurred.
                     // Note the ! sign (null-forgiving operator) at the end of the command.
-                    var exception = args.Outcome.Exception!; //The Exception property is nullable
+                    var exception = args.Outcome.Exception!; // The Exception property is nullable
 
                     // Tell the user what happened
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
@@ -70,19 +63,14 @@ namespace PollyDemos.Sync
                 {
                     // Retry the following call according to the strategy.
                     // The cancellationToken passed in to Execute() enables the strategy to cancel retries, when the token is signalled.
-                    strategy.Execute(ct =>
+                    strategy.Execute(token =>
                     {
                         // This code is executed within the strategy
 
-                        // Make a request and get a response
-                        var url = $"{Configuration.WEB_API_ROOT}/api/values/{totalRequests}";
-                        var response = client.Send(new HttpRequestMessage(HttpMethod.Get, url), ct);
-
-                        // Display the response message on the console
-                        using var stream = response.Content.ReadAsStream(ct);
-                        using var streamReader = new StreamReader(stream);
-                        progress.Report(ProgressWithMessage($"Response : {streamReader.ReadToEnd()}", Color.Green));
+                        var responseBody = IssueRequestAndProcessResponse(client, token);
+                        progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
                         eventualSuccesses++;
+
                     }, cancellationToken);
                 }
                 catch (Exception e)

--- a/PollyDemos/Sync/Demo08_Pipeline-Fallback-WaitAndRetry-CircuitBreaker.cs
+++ b/PollyDemos/Sync/Demo08_Pipeline-Fallback-WaitAndRetry-CircuitBreaker.cs
@@ -19,9 +19,6 @@ namespace PollyDemos.Sync
     /// </summary>
     public class Demo08_Pipeline_Fallback_WaitAndRetry_CircuitBreaker : SyncDemo
     {
-        private int totalRequests;
-        private int eventualSuccesses;
-        private int retries;
         private int eventualFailuresDueToCircuitBreaking;
         private int eventualFailuresForOtherReasons;
 
@@ -41,9 +38,7 @@ namespace PollyDemos.Sync
             eventualFailuresForOtherReasons = 0;
             totalRequests = 0;
 
-            progress.Report(ProgressWithMessage(nameof(Demo08_Pipeline_Fallback_WaitAndRetry_CircuitBreaker)));
-            progress.Report(ProgressWithMessage("======"));
-            progress.Report(ProgressWithMessage(string.Empty));
+            PrintHeader(progress, nameof(Demo08_Pipeline_Fallback_WaitAndRetry_CircuitBreaker));
 
             Stopwatch? watch = null;
 
@@ -66,7 +61,7 @@ namespace PollyDemos.Sync
 
                     // Due to how we have defined ShouldHandle, this delegate is called only if an exception occurred.
                     // Note the ! sign (null-forgiving operator) at the end of the command.
-                    var exception = args.Outcome.Exception!; //The Exception property is nullable
+                    var exception = args.Outcome.Exception!; // The Exception property is nullable
                     progress.Report(ProgressWithMessage($"..due to: {exception.Message}", Color.Magenta));
                     return default;
                 },
@@ -94,7 +89,7 @@ namespace PollyDemos.Sync
                 {
                     // Due to how we have defined ShouldHandle, this delegate is called only if an exception occurred.
                     // Note the ! sign (null-forgiving operator) at the end of the command.
-                    var exception = args.Outcome.Exception!; //The Exception property is nullable
+                    var exception = args.Outcome.Exception!; // The Exception property is nullable
 
                     // Tell the user what happened
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
@@ -114,7 +109,7 @@ namespace PollyDemos.Sync
 
                     // Due to how we have defined ShouldHandle, this delegate is called only if an exception occurred.
                     // Note the ! sign (null-forgiving operator) at the end of the command.
-                    var exception = args.Outcome.Exception!; //The Exception property is nullable
+                    var exception = args.Outcome.Exception!; // The Exception property is nullable
 
                     progress.Report(ProgressWithMessage($"Fallback catches failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
                     eventualFailuresDueToCircuitBreaking++;
@@ -133,7 +128,7 @@ namespace PollyDemos.Sync
 
                     // Due to how we have defined ShouldHandle, this delegate is called only if an exception occurred.
                     // Note the ! sign (null-forgiving operator) at the end of the command.
-                    var exception = args.Outcome.Exception!; //The Exception property is nullable
+                    var exception = args.Outcome.Exception!; // The Exception property is nullable
 
                     progress.Report(ProgressWithMessage($"Fallback catches eventually failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
 
@@ -151,6 +146,7 @@ namespace PollyDemos.Sync
 
             var client = new HttpClient();
             var internalCancel = false;
+
             // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
@@ -160,21 +156,12 @@ namespace PollyDemos.Sync
                 try
                 {
                     // Manage the call according to the pipeline.
-                    var response = pipeline.Execute(ct =>
-                    {
-                        // Make a request and get a response
-                        var url = $"{Configuration.WEB_API_ROOT}/api/values/{totalRequests}";
-                        var response = client.Send(new HttpRequestMessage(HttpMethod.Get, url), ct);
-
-                        using var stream = response.Content.ReadAsStream(ct);
-                        using var streamReader = new StreamReader(stream);
-                        return streamReader.ReadToEnd();
-                    }, cancellationToken);
+                    var responseBody = pipeline.Execute(token => IssueRequestAndProcessResponse(client, token), cancellationToken);
 
                     watch.Stop();
 
                     // Display the response message on the console
-                    progress.Report(ProgressWithMessage($"Response : {response} (after {watch.ElapsedMilliseconds}ms)", Color.Green));
+                    progress.Report(ProgressWithMessage($"Response : {responseBody} (after {watch.ElapsedMilliseconds}ms)", Color.Green));
                     eventualSuccesses++;
                 }
                 // This try-catch is not needed, since we have a Fallback for any Exceptions.

--- a/PollyDemos/Sync/SyncDemo.cs
+++ b/PollyDemos/Sync/SyncDemo.cs
@@ -4,6 +4,23 @@ namespace PollyDemos.Sync
 {
     public abstract class SyncDemo : DemoBase
     {
+        protected int totalRequests = 0;
+        protected int retries = 0;
+        protected int eventualSuccesses;
+        protected int eventualFailures;
+
         public abstract void Execute(CancellationToken cancellationToken, IProgress<DemoProgress> progress);
+
+        protected string IssueRequestAndProcessResponse(HttpClient client, CancellationToken cancellationToken = default)
+        {
+            // Make a request and get a response
+            var url = $"{Configuration.WEB_API_ROOT}/api/values/{totalRequests}";
+            var response = client.Send(new HttpRequestMessage(HttpMethod.Get, url), cancellationToken);
+
+            // Read response's body
+            using var stream = response.Content.ReadAsStream(cancellationToken);
+            using var streamReader = new StreamReader(stream);
+            return streamReader.ReadToEnd();
+        }
     }
 }


### PR DESCRIPTION
# Description
- Extracted the common fields that are used for statistics
- Extracted header printing logic to reduce noise
- Extracted request issuing and response processing logic 
- Renamed the `ct` parameters to `token`

With these changes the demos are more focused on the Polly stuff and less about the related boiler-plate code.