### PR TITLE
Migrate async bulkhead demos

### DIFF
--- a/PollyDemos/Async/AsyncBulkheadDemo.cs
+++ b/PollyDemos/Async/AsyncBulkheadDemo.cs
@@ -1,0 +1,31 @@
+namespace PollyDemos.Async
+{
+    public abstract class AsyncBulkheadDemo : AsyncDemo
+    {
+        // Track the number of 'good' and 'faulting' requests made, succeeded and failed.
+        // At any time, requests pending = made - succeeded - failed.
+        protected int goodRequestsMade;
+        protected int goodRequestsSucceeded;
+        protected int goodRequestsFailed;
+        protected int faultingRequestsMade;
+        protected int faultingRequestsSucceeded;
+        protected int faultingRequestsFailed;
+
+        protected async Task<string> IssueFaultingRequestAndProcessResponseAsync(HttpClient client, CancellationToken cancellationToken)
+            => await IssueRequestAndProcessResponseAsync(client, "nonthrottledfaulting", cancellationToken);
+
+        protected async Task<string> IssueGoodRequestAndProcessResponseAsync(HttpClient client, CancellationToken cancellationToken)
+            => await IssueRequestAndProcessResponseAsync(client, "nonthrottledgood", cancellationToken);
+
+        private async Task<string> IssueRequestAndProcessResponseAsync(HttpClient client, string route, CancellationToken cancellationToken)
+        {
+            var response = await client
+                .GetAsync($"{Configuration.WEB_API_ROOT}/api/{route}/{totalRequests}", cancellationToken)
+                .ConfigureAwait(false);
+            var responseBody = await response.Content
+                .ReadAsStringAsync(cancellationToken)
+                .ConfigureAwait(false);
+            return responseBody;
+        }
+    }
+}

--- a/PollyDemos/Async/BulkheadAsyncDemo00_NoIsolation.cs
+++ b/PollyDemos/Async/BulkheadAsyncDemo00_NoIsolation.cs
@@ -1,13 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Polly;
-using Polly.Bulkhead;
-using Polly.Timeout;
+﻿using System.Collections.Concurrent;
 using PollyDemos.OutputHelpers;
 
 namespace PollyDemos.Async
@@ -16,12 +7,12 @@ namespace PollyDemos.Async
     /// Imagine a microservice or web front end (the upstream caller) trying to call two endpoints on a downstream system.
     /// The 'good' endpoint responds quickly.  The 'faulting' endpoint faults, and responds slowly.
     /// Imagine the _caller_ has limited capacity (all single instances of upstream services/webapps eventually hit some capacity limit).
-    /// 
-    /// This demo 00 does not separate call streams into separate bulkheads.  
+    ///
+    /// This demo 00 does not separate call streams into separate bulkheads.
     /// A random combination of calls to the 'good' and 'faulting' endpoint are made.
-    /// 
-    /// Observe: --
-    /// Because bulkheads do not isolate the separate streams of calls, 
+    ///
+    /// Observations:
+    /// Because bulkheads do not isolate the separate streams of calls,
     /// eventually all the caller's capacity is taken up waiting on the 'faulting' downstream calls.
     /// So the performance of 'good' calls is starved of resource, and starts suffering too.
     /// Watch how the number of pending and failing calls to the good endpoint also climbs,
@@ -31,169 +22,78 @@ namespace PollyDemos.Async
     {
         // Track the number of 'good' and 'faulting' requests made, succeeded and failed.
         // At any time, requests pending = made - succeeded - failed.
-        private int totalRequests = 0;
-        private int goodRequestsMade = 0;
-        private int goodRequestsSucceeded = 0;
-        private int goodRequestsFailed = 0;
-        private int faultingRequestsMade = 0;
-        private int faultingRequestsSucceeded = 0;
-        private int faultingRequestsFailed = 0;
+        private int goodRequestsMade;
+        private int goodRequestsSucceeded;
+        private int goodRequestsFailed;
+        private int faultingRequestsMade;
+        private int faultingRequestsSucceeded;
+        private int faultingRequestsFailed;
+
+        // Let's imagine this caller has some theoretically limited capacity, so that *it* will suffer capacity-starvation, if the downstream system is faulting.
+        // In demo 00, all calls share the same bulkhead.
+        private readonly ResiliencePipeline sharedBulkhead = new ResiliencePipelineBuilder()
+                .AddConcurrencyLimiter(
+                    permitLimit: 8,  // (artificially low - but easier to follow, to illustrate principle)
+                    queueLimit: 1)
+                .Build();
 
         public override string Description =>
-            "Demonstrates a good call stream and faulting call stream sharing resources.  Good call stream throughput is blocked by the faulting call stream.";
+            "Demonstrates a good call stream and faulting call stream sharing resources. Good call stream throughput is blocked by the faulting call stream.";
 
-        public override async Task ExecuteAsync(CancellationToken externalCancellationToken,
-            IProgress<DemoProgress> progress)
+        public override async Task ExecuteAsync(CancellationToken externalCancellationToken, IProgress<DemoProgress> progress)
         {
-            if (progress == null) throw new ArgumentNullException(nameof(progress));
+            ArgumentNullException.ThrowIfNull(progress);
 
-            progress.Report(ProgressWithMessage(nameof(BulkheadAsyncDemo00_NoIsolation)));
-            progress.Report(ProgressWithMessage("======"));
-            progress.Report(ProgressWithMessage(string.Empty));
-
-            // Let's imagine this caller has some theoretically limited capacity, so that *it* will suffer capacity-starvation, if the downstream system is faulting.
-            const int callerParallelCapacity = 8; // (artificially low - but easier to follow, to illustrate principle)
-            // In demo 00, all calls share the same bulkhead.
-            var sharedBulkhead = Policy.BulkheadAsync(callerParallelCapacity, 1);
-
-            var rand = new Random();
+            PrintHeader(progress, nameof(BulkheadAsyncDemo00_NoIsolation));
             totalRequests = 0;
 
             await Task.FromResult(true).ConfigureAwait(false); // Ensure none of what follows runs synchronously.
 
-            IList<Task> tasks = new List<Task>();
+            var tasks = new List<Task>();
             var internalCancellationTokenSource = new CancellationTokenSource();
             var combinedToken = CancellationTokenSource
-                .CreateLinkedTokenSource(externalCancellationToken, internalCancellationTokenSource.Token).Token;
+                .CreateLinkedTokenSource(externalCancellationToken, internalCancellationTokenSource.Token)
+                .Token;
 
-            var messages = new ConcurrentQueue<ColoredMessage>();
+            var messages = new ConcurrentQueue<(string Message, Color Color)>();
+            var client = new HttpClient();
+            var internalCancel = false;
+            var rand = new Random();
 
-            using (var client = new HttpClient())
+            while (!(internalCancel || externalCancellationToken.IsCancellationRequested))
             {
-                var internalCancel = false;
-                while (!internalCancel && !externalCancellationToken.IsCancellationRequested)
+                totalRequests++;
+                var thisRequest = totalRequests;
+
+                // Randomly make either 'good' or 'faulting' calls.
+                if (rand.Next(0, 2) == 0)
                 {
-                    totalRequests++;
+                    goodRequestsMade++;
+                    tasks.Add(CallGoodEndpoint(client, messages, thisRequest, combinedToken));
+                }
+                else
+                {
+                    faultingRequestsMade++;
+                    tasks.Add(CallFaultingEndpoint(client, messages, thisRequest, combinedToken));
+                }
 
-                    var thisRequest = totalRequests;
+                AddSummary(messages);
 
-                    // Randomly make either 'good' or 'faulting' calls.
-                    if (rand.Next(0, 2) == 0)
-                    {
-                        goodRequestsMade++;
-                        // Call 'good' endpoint.
-                        tasks.Add(sharedBulkhead.ExecuteAsync(async ct =>
-                            {
-                                try
-                                {
-                                    // Make a request and get a response, from the good endpoint
-                                    var msg = await (await client
-                                            .GetAsync(
-                                                Configuration.WEB_API_ROOT + "/api/nonthrottledgood/" + totalRequests,
-                                                ct).ConfigureAwait(false)).Content.ReadAsStringAsync()
-                                        .ConfigureAwait(false);
-                                    if (!ct.IsCancellationRequested)
-                                        messages.Enqueue(new ColoredMessage($"Response: {msg}", Color.Green));
+                // Output all messages available right now.
+                while (messages.TryDequeue(out var tuple))
+                {
+                    progress.Report(ProgressWithMessage(tuple.Message, tuple.Color));
+                }
 
-                                    goodRequestsSucceeded++;
-                                }
-                                catch (Exception e)
-                                {
-                                    if (!ct.IsCancellationRequested)
-                                        messages.Enqueue(new ColoredMessage(
-                                            $"Request {thisRequest} eventually failed with: {e.Message}", Color.Red));
-
-                                    goodRequestsFailed++;
-                                }
-                            }, combinedToken)
-                            .ContinueWith((t, k) =>
-                            {
-                                if (t.IsFaulted)
-                                    messages.Enqueue(new ColoredMessage(
-                                        $"Request {k} failed with: {t.Exception.Flatten().InnerExceptions.First().Message}",
-                                        Color.Red));
-
-                                goodRequestsFailed++;
-                            }, thisRequest, TaskContinuationOptions.NotOnRanToCompletion)
-                        );
-                    }
-                    else
-                    {
-                        faultingRequestsMade++;
-                        // call 'faulting' endpoint.
-                        tasks.Add(sharedBulkhead.ExecuteAsync(async ct =>
-                            {
-                                try
-                                {
-                                    // Make a request and get a response, from the faulting endpoint
-                                    var msg = await (await client
-                                            .GetAsync(
-                                                Configuration.WEB_API_ROOT + "/api/nonthrottledfaulting/" +
-                                                totalRequests,
-                                                ct).ConfigureAwait(false)).Content.ReadAsStringAsync()
-                                        .ConfigureAwait(false);
-                                    if (!combinedToken.IsCancellationRequested)
-                                        messages.Enqueue(new ColoredMessage($"Response: {msg}", Color.Green));
-
-                                    faultingRequestsSucceeded++;
-                                }
-                                catch (Exception e)
-                                {
-                                    if (!ct.IsCancellationRequested)
-                                        messages.Enqueue(new ColoredMessage(
-                                            $"Request {thisRequest} eventually failed with: {e.Message}", Color.Red));
-
-                                    faultingRequestsFailed++;
-                                }
-                            }, combinedToken)
-                            .ContinueWith((t, k) =>
-                            {
-                                if (t.IsFaulted)
-                                    messages.Enqueue(new ColoredMessage(
-                                        $"Request {k} failed with: {t.Exception.Flatten().InnerExceptions.First().Message}",
-                                        Color.Red));
-
-                                faultingRequestsFailed++;
-                            }, thisRequest, TaskContinuationOptions.NotOnRanToCompletion)
-                        );
-                    }
-
-                    messages.Enqueue(new ColoredMessage($"Total requests: requested {totalRequests:00}, ",
-                        Color.White));
-                    messages.Enqueue(new ColoredMessage($"Good endpoint: requested {goodRequestsMade:00}, ",
-                        Color.White));
-                    messages.Enqueue(new ColoredMessage($"Good endpoint:succeeded {goodRequestsSucceeded:00}, ",
-                        Color.Green));
-                    messages.Enqueue(new ColoredMessage(
-                        $"Good endpoint:pending {goodRequestsMade - goodRequestsSucceeded - goodRequestsFailed:00}, ",
-                        Color.Yellow));
-                    messages.Enqueue(new ColoredMessage($"Good endpoint:failed {goodRequestsFailed:00}.", Color.Red));
-
-                    messages.Enqueue(new ColoredMessage(string.Empty));
-                    messages.Enqueue(new ColoredMessage($"Faulting endpoint: requested {faultingRequestsMade:00}, ",
-                        Color.White));
-                    messages.Enqueue(new ColoredMessage($"Faulting endpoint:succeeded {faultingRequestsSucceeded:00}, ",
-                        Color.Green));
-                    messages.Enqueue(new ColoredMessage(
-                        $"Faulting endpoint:pending {faultingRequestsMade - faultingRequestsSucceeded - faultingRequestsFailed:00}, ",
-                        Color.Yellow));
-                    messages.Enqueue(new ColoredMessage($"Faulting endpoint:failed {faultingRequestsFailed:00}.",
-                        Color.Red));
-                    messages.Enqueue(new ColoredMessage(string.Empty));
-
-                    // Output all messages available right now, in one go.
-                    progress.Report(ProgressWithMessages(ConsumeAsEnumerable(messages)));
-
-                    // Wait briefly
-                    await Task.Delay(TimeSpan.FromSeconds(0.2), externalCancellationToken).ConfigureAwait(false);
-                    // Support cancellation by keyboard, when called from a console; ignore exceptions, if console not accessible.
-                    try
-                    {
-                        internalCancel = Console.KeyAvailable;
-                    }
-                    catch
-                    {
-                    }
+                // Wait briefly
+                await Task.Delay(TimeSpan.FromSeconds(0.2), externalCancellationToken).ConfigureAwait(false);
+                // Support cancellation by keyboard, when called from a console; ignore exceptions, if console not accessible.
+                try
+                {
+                    internalCancel = Console.KeyAvailable;
+                }
+                catch
+                {
                 }
             }
 
@@ -207,28 +107,125 @@ namespace PollyDemos.Async
             {
                 // Swallow any shutdown exceptions eg TaskCanceledException - we don't care - we are shutting down the demo.
             }
-
-            sharedBulkhead.Dispose();
         }
 
-        public static IEnumerable<T> ConsumeAsEnumerable<T>(ConcurrentQueue<T> concurrentQueue)
+        private void AddSummary(ConcurrentQueue<(string Message, Color Color)> messages)
         {
-            while (concurrentQueue.TryDequeue(out var got)) yield return got;
+            messages.Enqueue(($"Total requests: requested {totalRequests:00}, ", Color.White));
+            messages.Enqueue(($"Good endpoint: requested {goodRequestsMade:00}, ", Color.White));
+            messages.Enqueue(($"Good endpoint:succeeded {goodRequestsSucceeded:00}, ", Color.Green));
+            messages.Enqueue(($"Good endpoint:pending {goodRequestsMade - goodRequestsSucceeded - goodRequestsFailed:00}, ", Color.Yellow));
+            messages.Enqueue(($"Good endpoint:failed {goodRequestsFailed:00}.", Color.Red));
+            messages.Enqueue((string.Empty, Color.Default));
+
+            messages.Enqueue(($"Faulting endpoint: requested {faultingRequestsMade:00}, ", Color.White));
+            messages.Enqueue(($"Faulting endpoint:succeeded {faultingRequestsSucceeded:00}, ", Color.Green));
+            messages.Enqueue(($"Faulting endpoint:pending {faultingRequestsMade - faultingRequestsSucceeded - faultingRequestsFailed:00}, ", Color.Yellow));
+            messages.Enqueue(($"Faulting endpoint:failed {faultingRequestsFailed:00}.", Color.Red));
+            messages.Enqueue((string.Empty, Color.Default));
         }
 
-        public override Statistic[] LatestStatistics => new[]
+        private Task CallFaultingEndpoint(HttpClient client, ConcurrentQueue<(string Message, Color Color)> messages, int thisRequest, CancellationToken combinedToken)
         {
-            new Statistic("Total requests made", totalRequests, Color.Default),
-            new Statistic("Good endpoint: requested", goodRequestsMade, Color.Default),
-            new Statistic("Good endpoint: succeeded", goodRequestsSucceeded, Color.Green),
-            new Statistic("Good endpoint: pending", goodRequestsMade - goodRequestsSucceeded - goodRequestsFailed,
-                Color.Yellow),
-            new Statistic("Good endpoint: failed", goodRequestsFailed, Color.Red),
-            new Statistic("Faulting endpoint: requested", faultingRequestsMade, Color.Default),
-            new Statistic("Faulting endpoint: succeeded", faultingRequestsSucceeded, Color.Green),
-            new Statistic("Faulting endpoint: pending",
-                faultingRequestsMade - faultingRequestsSucceeded - faultingRequestsFailed, Color.Yellow),
-            new Statistic("Faulting endpoint: failed", faultingRequestsFailed, Color.Red),
+            ValueTask issueRequest = sharedBulkhead.ExecuteAsync(async token =>
+            {
+                try
+                {
+                    // Make a request and get a response, from the faulting endpoint
+                    var response = await client
+                        .GetAsync($"{Configuration.WEB_API_ROOT}/api/nonthrottledfaulting/{totalRequests}", token)
+                        .ConfigureAwait(false);
+                    var responseBody = await response.Content
+                        .ReadAsStringAsync(token)
+                        .ConfigureAwait(false);
+
+                    if (!combinedToken.IsCancellationRequested)
+                    {
+                        messages.Enqueue(($"Response: {responseBody}", Color.Green));
+                    }
+                    faultingRequestsSucceeded++;
+                }
+                catch (Exception e)
+                {
+                    if (!token.IsCancellationRequested)
+                    {
+                        messages.Enqueue(($"Request {thisRequest} eventually failed with: {e.Message}", Color.Red));
+                    }
+                    faultingRequestsFailed++;
+                }
+            }, combinedToken);
+
+            Task handleFailure = issueRequest
+                .AsTask()
+                .ContinueWith((failedTask, state) =>
+                {
+                    if (failedTask.IsFaulted)
+                    {
+                        var message = $"Request {state} failed with: {failedTask.Exception!.Flatten().InnerExceptions.First().Message}";
+                        messages.Enqueue((message, Color.Red));
+                    }
+                    faultingRequestsFailed++;
+                }, thisRequest, TaskContinuationOptions.NotOnRanToCompletion);
+
+            return handleFailure;
+        }
+
+        private Task CallGoodEndpoint(HttpClient client, ConcurrentQueue<(string Message, Color Color)> messages, int thisRequest, CancellationToken combinedToken)
+        {
+            ValueTask issueRequest = sharedBulkhead.ExecuteAsync(async token =>
+            {
+                try
+                {
+                    // Make a request and get a response, from the good endpoint
+                    var response = await client
+                        .GetAsync($"{Configuration.WEB_API_ROOT}/api/nonthrottledgood/{totalRequests}", token)
+                        .ConfigureAwait(false);
+                    var responseBody = await response.Content
+                        .ReadAsStringAsync(token)
+                        .ConfigureAwait(false);
+
+                    if (!token.IsCancellationRequested)
+                    {
+                        messages.Enqueue(($"Response: {responseBody}", Color.Green));
+                    }
+                    goodRequestsSucceeded++;
+                }
+                catch (Exception e)
+                {
+                    if (!token.IsCancellationRequested)
+                    {
+                        messages.Enqueue(($"Request {thisRequest} eventually failed with: {e.Message}", Color.Red));
+                    }
+                    goodRequestsFailed++;
+                }
+            }, combinedToken);
+
+            Task handleFailure = issueRequest
+                .AsTask()
+                .ContinueWith((failedTask, state) =>
+                {
+                    if (failedTask.IsFaulted)
+                    {
+                        var message = $"Request {state} failed with: {failedTask.Exception!.Flatten().InnerExceptions.First().Message}";
+                        messages.Enqueue((message, Color.Red));
+                    }
+                    goodRequestsFailed++;
+                }, thisRequest, TaskContinuationOptions.NotOnRanToCompletion);
+
+            return handleFailure;
+        }
+
+        public override Statistic[] LatestStatistics => new Statistic[]
+        {
+            new("Total requests made", totalRequests, Color.Default),
+            new("Good endpoint: requested", goodRequestsMade, Color.Default),
+            new("Good endpoint: succeeded", goodRequestsSucceeded, Color.Green),
+            new("Good endpoint: pending", goodRequestsMade - goodRequestsSucceeded - goodRequestsFailed, Color.Yellow),
+            new("Good endpoint: failed", goodRequestsFailed, Color.Red),
+            new("Faulting endpoint: requested", faultingRequestsMade, Color.Default),
+            new("Faulting endpoint: succeeded", faultingRequestsSucceeded, Color.Green),
+            new("Faulting endpoint: pending", faultingRequestsMade - faultingRequestsSucceeded - faultingRequestsFailed, Color.Yellow),
+            new("Faulting endpoint: failed", faultingRequestsFailed, Color.Red),
         };
     }
 }

--- a/PollyDemos/Async/BulkheadAsyncDemo01_WithBulkheads.cs
+++ b/PollyDemos/Async/BulkheadAsyncDemo01_WithBulkheads.cs
@@ -1,13 +1,4 @@
-﻿using Polly;
-using Polly.Bulkhead;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Polly.Timeout;
+﻿using System.Collections.Concurrent;
 using PollyDemos.OutputHelpers;
 
 namespace PollyDemos.Async
@@ -17,213 +8,204 @@ namespace PollyDemos.Async
     /// Imagine a microservice or web front end (the upstream caller) trying to call two endpoints on a downstream system.
     /// The 'good' endpoint responds quickly.  The 'faulting' endpoint faults, and responds slowly.
     /// Imagine the _caller_ has limited capacity (all single instances of services/webapps eventually hit some capacity limit).
-    /// 
-    /// Compared to bulkhead demo 00, this demo 01 isolates the calls 
+    ///
+    /// Compared to bulkhead demo 00, this demo 01 isolates the calls
     /// to the 'good' and 'faulting' endpoints in separate bulkheads.
     /// A random combination of calls to the 'good' and 'faulting' endpoint are made.
-    /// 
-    /// Observe --
-    /// Because the separate 'good' and 'faulting' streams are isolated in separate bulkheads, 
-    /// the 'faulting' calls stil back up (high pending and failing number), but 
+    ///
+    /// Observations:
+    /// Because the separate 'good' and 'faulting' streams are isolated in separate bulkheads,
+    /// the 'faulting' calls still back up (high pending and failing number), but
     /// 'good' calls (in a separate bulkhead) are *unaffected* (all succeed; none pending or failing).
-    /// 
+    ///
     /// Bulkheads: making sure one fault doesn't sink the whole ship!
     /// </summary>
-    public class BulkheadAsyncDemo01_WithBulkheads : AsyncDemo
+    public class BulkheadAsyncDemo01_WithBulkheads : AsyncBulkheadDemo
     {
-        // Track the number of 'good' and 'faulting' requests made, succeeded and failed.
-        // At any time, requests pending = made - succeeded - failed.
-        private int totalRequests = 0;
-        private int goodRequestsMade = 0;
-        private int goodRequestsSucceeded = 0;
-        private int goodRequestsFailed = 0;
-        private int faultingRequestsMade = 0;
-        private int faultingRequestsSucceeded = 0;
-        private int faultingRequestsFailed = 0;
+         // Let's imagine this caller has some theoretically limited capacity.
+        const int callerParallelCapacity = 8; // artificially low - but easier to follow, to illustrate principle
+
+        private readonly ResiliencePipeline bulkheadForGoodCalls = new ResiliencePipelineBuilder()
+            .AddConcurrencyLimiter(
+                permitLimit: callerParallelCapacity / 2,
+                queueLimit: 10)
+            .Build();
+
+        // In this demo we let any number (int.MaxValue) of calls _queue for an execution slot in the bulkhead (simulating a system still _trying to accept/process as many of the calls as possible).
+        // A subsequent demo will look at using no queue (and bulkhead rejections) to simulate automated horizontal scaling.
+        private readonly ResiliencePipeline bulkheadForFaultingCalls =
+            new ResiliencePipelineBuilder()
+            .AddConcurrencyLimiter(
+                permitLimit: callerParallelCapacity - callerParallelCapacity / 2,
+                queueLimit: 10)
+            .Build();
 
         public override string Description =>
-            "Demonstrates a good call stream and faulting call stream separated into separate bulkheads.  The faulting call stream is isolated from affecting the good call stream.";
+            "Demonstrates a good call stream and faulting call stream separated into separate bulkheads. The faulting call stream is isolated from affecting the good call stream.";
 
-        public override async Task ExecuteAsync(CancellationToken externalCancellationToken,
-            IProgress<DemoProgress> progress)
+        public override async Task ExecuteAsync(CancellationToken externalCancellationToken, IProgress<DemoProgress> progress)
         {
-            if (progress == null) throw new ArgumentNullException(nameof(progress));
+            ArgumentNullException.ThrowIfNull(nameof(progress));
 
-            progress.Report(ProgressWithMessage(nameof(BulkheadAsyncDemo01_WithBulkheads)));
-            progress.Report(ProgressWithMessage("======"));
-            progress.Report(ProgressWithMessage(string.Empty));
-
-            // Let's imagine this caller has some theoretically limited capacity.
-            const int callerParallelCapacity = 8; // (artificially low - but easier to follow, to illustrate principle)
-
-            var bulkheadForGoodCalls = Policy.BulkheadAsync(callerParallelCapacity / 2, 10);
-            var bulkheadForFaultingCalls =
-                Policy.BulkheadAsync(callerParallelCapacity - callerParallelCapacity / 2,
-                    10); // In this demo we let any number (int.MaxValue) of calls _queue for an execution slot in the bulkhead (simulating a system still _trying to accept/process as many of the calls as possible).  A subsequent demo will look at using no queue (and bulkhead rejections) to simulate automated horizontal scaling.
-
-            var rand = new Random();
+            PrintHeader(progress, nameof(BulkheadAsyncDemo01_WithBulkheads));
             totalRequests = 0;
 
             await Task.FromResult(true).ConfigureAwait(false); // Ensure none of what follows runs synchronously.
 
-            IList<Task> tasks = new List<Task>();
+            var tasks = new List<Task>();
             var internalCancellationTokenSource = new CancellationTokenSource();
             var combinedToken = CancellationTokenSource
-                .CreateLinkedTokenSource(externalCancellationToken, internalCancellationTokenSource.Token).Token;
+                .CreateLinkedTokenSource(externalCancellationToken, internalCancellationTokenSource.Token)
+                .Token;
 
-            var messages = new ConcurrentQueue<ColoredMessage>();
+            var messages = new ConcurrentQueue<(string Message, Color Color)>();
+            var client = new HttpClient();
+            var internalCancel = false;
+            var rand = new Random();
 
-            using (var client = new HttpClient())
+            while (!(internalCancel || externalCancellationToken.IsCancellationRequested))
             {
-                var internalCancel = false;
-                while (!internalCancel && !externalCancellationToken.IsCancellationRequested)
+                totalRequests++;
+                var thisRequest = totalRequests;
+
+                // Randomly make either 'good' or 'faulting' calls.
+                if (rand.Next(0, 2) == 0)
                 {
-                    totalRequests++;
+                    goodRequestsMade++;
+                    tasks.Add(CallGoodEndpoint(client, messages, thisRequest, combinedToken));
+                }
+                else
+                {
+                    faultingRequestsMade++;
+                    tasks.Add(CallFaultingEndpoint(client, messages, thisRequest, combinedToken));
+                }
 
-                    var thisRequest = totalRequests;
+                AddSummary(messages);
 
-                    // Randomly make either 'good' or 'faulting' calls.
-                    if (rand.Next(0, 2) == 0)
-                    {
-                        goodRequestsMade++;
-                        // Call 'good' endpoint.
-                        tasks.Add(bulkheadForGoodCalls.ExecuteAsync(async ct =>
-                            {
-                                try
-                                {
-                                    // Make a request and get a response, from the good endpoint
-                                    var msg = await (await client
-                                            .GetAsync(
-                                                Configuration.WEB_API_ROOT + "/api/nonthrottledgood/" + totalRequests,
-                                                ct).ConfigureAwait(false)).Content.ReadAsStringAsync()
-                                        .ConfigureAwait(false);
-                                    if (!ct.IsCancellationRequested)
-                                        messages.Enqueue(new ColoredMessage($"Response: {msg}", Color.Green));
+                // Output all messages available right now.
+                while (messages.TryDequeue(out var tuple))
+                {
+                    progress.Report(ProgressWithMessage(tuple.Message, tuple.Color));
+                }
 
-                                    goodRequestsSucceeded++;
-                                }
-                                catch (Exception e)
-                                {
-                                    if (!ct.IsCancellationRequested)
-                                        messages.Enqueue(new ColoredMessage(
-                                            $"Request {thisRequest} eventually failed with: {e.Message}", Color.Red));
-
-                                    goodRequestsFailed++;
-                                }
-                            }, combinedToken)
-                            .ContinueWith((t, k) =>
-                            {
-                                if (t.IsFaulted)
-                                    messages.Enqueue(new ColoredMessage(
-                                        $"Request {k} failed with: {t.Exception.Flatten().InnerExceptions.First().Message}",
-                                        Color.Red));
-
-                                goodRequestsFailed++;
-                            }, thisRequest, TaskContinuationOptions.NotOnRanToCompletion)
-                        );
-                    }
-                    else
-                    {
-                        faultingRequestsMade++;
-                        // call 'faulting' endpoint.
-                        tasks.Add(bulkheadForFaultingCalls.ExecuteAsync(async ct =>
-                            {
-                                try
-                                {
-                                    // Make a request and get a response, from the faulting endpoint
-                                    var msg = await (await client
-                                            .GetAsync(
-                                                Configuration.WEB_API_ROOT + "/api/nonthrottledfaulting/" +
-                                                totalRequests,
-                                                ct).ConfigureAwait(false)).Content.ReadAsStringAsync()
-                                        .ConfigureAwait(false);
-                                    if (!combinedToken.IsCancellationRequested)
-                                        messages.Enqueue(new ColoredMessage($"Response: {msg}", Color.Green));
-
-                                    faultingRequestsSucceeded++;
-                                }
-                                catch (Exception e)
-                                {
-                                    if (!ct.IsCancellationRequested)
-                                        messages.Enqueue(new ColoredMessage(
-                                            $"Request {thisRequest} eventually failed with: {e.Message}", Color.Red));
-
-                                    faultingRequestsFailed++;
-                                }
-                            }, combinedToken)
-                            .ContinueWith((t, k) =>
-                            {
-                                if (t.IsFaulted)
-                                    messages.Enqueue(new ColoredMessage(
-                                        $"Request {k} failed with: {t.Exception.Flatten().InnerExceptions.First().Message}",
-                                        Color.Red));
-
-                                faultingRequestsFailed++;
-                            }, thisRequest, TaskContinuationOptions.NotOnRanToCompletion)
-                        );
-                    }
-
-                    messages.Enqueue(new ColoredMessage($"Total requests: requested {totalRequests:00}, ",
-                        Color.White));
-                    messages.Enqueue(new ColoredMessage($"Good endpoint: requested {goodRequestsMade:00}, ",
-                        Color.White));
-                    messages.Enqueue(new ColoredMessage($"Good endpoint:succeeded {goodRequestsSucceeded:00}, ",
-                        Color.Green));
-                    messages.Enqueue(new ColoredMessage(
-                        $"Good endpoint:pending {goodRequestsMade - goodRequestsSucceeded - goodRequestsFailed:00}, ",
-                        Color.Yellow));
-                    messages.Enqueue(new ColoredMessage($"Good endpoint:failed {goodRequestsFailed:00}.", Color.Red));
-
-                    messages.Enqueue(new ColoredMessage(string.Empty));
-                    messages.Enqueue(new ColoredMessage($"Faulting endpoint: requested {faultingRequestsMade:00}, ",
-                        Color.White));
-                    messages.Enqueue(new ColoredMessage($"Faulting endpoint:succeeded {faultingRequestsSucceeded:00}, ",
-                        Color.Green));
-                    messages.Enqueue(new ColoredMessage(
-                        $"Faulting endpoint:pending {faultingRequestsMade - faultingRequestsSucceeded - faultingRequestsFailed:00}, ",
-                        Color.Yellow));
-                    messages.Enqueue(new ColoredMessage($"Faulting endpoint:failed {faultingRequestsFailed:00}.",
-                        Color.Red));
-                    messages.Enqueue(new ColoredMessage(string.Empty));
-
-                    // Output all messages available right now, in one go.
-                    progress.Report(ProgressWithMessages(ConsumeAsEnumerable(messages)));
-
-                    // Wait briefly
-                    await Task.Delay(TimeSpan.FromSeconds(0.2), externalCancellationToken).ConfigureAwait(false);
-                    // Support cancellation by keyboard, when called from a console; ignore exceptions, if console not accessible.
-                    try
-                    {
-                        internalCancel = Console.KeyAvailable;
-                    }
-                    catch
-                    {
-                    }
+                // Wait briefly
+                await Task.Delay(TimeSpan.FromSeconds(0.2), externalCancellationToken).ConfigureAwait(false);
+                // Support cancellation by keyboard, when called from a console; ignore exceptions, if console not accessible.
+                try
+                {
+                    internalCancel = Console.KeyAvailable;
+                }
+                catch
+                {
                 }
             }
-
-            bulkheadForFaultingCalls.Dispose();
-            bulkheadForGoodCalls.Dispose();
         }
 
-        public static IEnumerable<T> ConsumeAsEnumerable<T>(ConcurrentQueue<T> concurrentQueue)
+        private void AddSummary(ConcurrentQueue<(string Message, Color Color)> messages)
         {
-            while (concurrentQueue.TryDequeue(out var got)) yield return got;
+            messages.Enqueue(($"Total requests: requested {totalRequests:00}, ", Color.White));
+            messages.Enqueue(($"Good endpoint: requested {goodRequestsMade:00}, ", Color.White));
+            messages.Enqueue(($"Good endpoint:succeeded {goodRequestsSucceeded:00}, ", Color.Green));
+            messages.Enqueue(($"Good endpoint:pending {goodRequestsMade - goodRequestsSucceeded - goodRequestsFailed:00}, ", Color.Yellow));
+            messages.Enqueue(($"Good endpoint:failed {goodRequestsFailed:00}.", Color.Red));
+            messages.Enqueue((string.Empty, Color.Default));
+
+            messages.Enqueue(($"Faulting endpoint: requested {faultingRequestsMade:00}, ", Color.White));
+            messages.Enqueue(($"Faulting endpoint:succeeded {faultingRequestsSucceeded:00}, ", Color.Green));
+            messages.Enqueue(($"Faulting endpoint:pending {faultingRequestsMade - faultingRequestsSucceeded - faultingRequestsFailed:00}, ", Color.Yellow));
+            messages.Enqueue(($"Faulting endpoint:failed {faultingRequestsFailed:00}.", Color.Red));
+            messages.Enqueue((string.Empty, Color.Default));
         }
 
-        public override Statistic[] LatestStatistics => new[]
+        private Task CallFaultingEndpoint(HttpClient client, ConcurrentQueue<(string Message, Color Color)> messages, int thisRequest, CancellationToken cancellationToken)
         {
-            new Statistic("Total requests made", totalRequests, Color.Default),
-            new Statistic("Good endpoint: requested", goodRequestsMade, Color.Default),
-            new Statistic("Good endpoint: succeeded", goodRequestsSucceeded, Color.Green),
-            new Statistic("Good endpoint: pending", goodRequestsMade - goodRequestsSucceeded - goodRequestsFailed,
-                Color.Yellow),
-            new Statistic("Good endpoint: failed", goodRequestsFailed, Color.Red),
-            new Statistic("Faulting endpoint: requested", faultingRequestsMade, Color.Default),
-            new Statistic("Faulting endpoint: succeeded", faultingRequestsSucceeded, Color.Green),
-            new Statistic("Faulting endpoint: pending",
-                faultingRequestsMade - faultingRequestsSucceeded - faultingRequestsFailed, Color.Yellow),
-            new Statistic("Faulting endpoint: failed", faultingRequestsFailed, Color.Red),
+            ValueTask issueRequest = bulkheadForGoodCalls.ExecuteAsync(async token =>
+            {
+                try
+                {
+                    var responseBody = await IssueFaultingRequestAndProcessResponseAsync(client, token).ConfigureAwait(false);
+
+                    if (!cancellationToken.IsCancellationRequested)
+                    {
+                        messages.Enqueue(($"Response: {responseBody}", Color.Green));
+                    }
+                    faultingRequestsSucceeded++;
+                }
+                catch (Exception e)
+                {
+                    if (!token.IsCancellationRequested)
+                    {
+                        messages.Enqueue(($"Request {thisRequest} eventually failed with: {e.Message}", Color.Red));
+                    }
+                    faultingRequestsFailed++;
+                }
+            }, cancellationToken);
+
+            Task handleFailure = issueRequest
+                .AsTask()
+                .ContinueWith((failedTask, state) =>
+                {
+                    if (failedTask.IsFaulted)
+                    {
+                        var message = $"Request {state} failed with: {failedTask.Exception!.Flatten().InnerExceptions.First().Message}";
+                        messages.Enqueue((message, Color.Red));
+                    }
+                    faultingRequestsFailed++;
+                }, thisRequest, TaskContinuationOptions.NotOnRanToCompletion);
+
+            return handleFailure;
+        }
+
+        private Task CallGoodEndpoint(HttpClient client, ConcurrentQueue<(string Message, Color Color)> messages, int thisRequest, CancellationToken cancellationToken)
+        {
+            ValueTask issueRequest = bulkheadForGoodCalls.ExecuteAsync(async token =>
+            {
+                try
+                {
+                    var responseBody = await IssueGoodRequestAndProcessResponseAsync(client, token).ConfigureAwait(false);
+
+                    if (!cancellationToken.IsCancellationRequested)
+                    {
+                        messages.Enqueue(($"Response: {responseBody}", Color.Green));
+                    }
+                    goodRequestsSucceeded++;
+                }
+                catch (Exception e)
+                {
+                    if (!token.IsCancellationRequested)
+                    {
+                        messages.Enqueue(($"Request {thisRequest} eventually failed with: {e.Message}", Color.Red));
+                    }
+                    goodRequestsFailed++;
+                }
+            }, cancellationToken);
+
+            Task handleFailure = issueRequest
+                .AsTask()
+                .ContinueWith((failedTask, state) =>
+                {
+                    if (failedTask.IsFaulted)
+                    {
+                        var message = $"Request {state} failed with: {failedTask.Exception!.Flatten().InnerExceptions.First().Message}";
+                        messages.Enqueue((message, Color.Red));
+                    }
+                    goodRequestsFailed++;
+                }, thisRequest, TaskContinuationOptions.NotOnRanToCompletion);
+
+            return handleFailure;
+        }
+
+        public override Statistic[] LatestStatistics => new Statistic[]
+        {
+            new("Total requests made", totalRequests, Color.Default),
+            new("Good endpoint: requested", goodRequestsMade, Color.Default),
+            new("Good endpoint: succeeded", goodRequestsSucceeded, Color.Green),
+            new("Good endpoint: pending", goodRequestsMade - goodRequestsSucceeded - goodRequestsFailed, Color.Yellow),
+            new("Good endpoint: failed", goodRequestsFailed, Color.Red),
+            new("Faulting endpoint: requested", faultingRequestsMade, Color.Default),
+            new("Faulting endpoint: succeeded", faultingRequestsSucceeded, Color.Green),
+            new("Faulting endpoint: pending", faultingRequestsMade - faultingRequestsSucceeded - faultingRequestsFailed, Color.Yellow),
+            new("Faulting endpoint: failed", faultingRequestsFailed, Color.Red),
         };
     }
 }

--- a/PollyDemos/PollyDemos.csproj
+++ b/PollyDemos/PollyDemos.csproj
@@ -10,9 +10,10 @@
     <NoWarn>$(NoWarn);SA1123;SA1515;CA2000;CA2007;CA1303;IDE0021;IDE0017;IDE0060;CS1998;CA1064;S3257;IDE0028;CA1031;CA1848</NoWarn>
     <RootNamespace>PollyDemos</RootNamespace>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Polly" Version="8.0.0" />
+    <PackageReference Include="Polly.RateLimiting" Version="8.0.0" />
     <Using Include="Polly" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description
- Migrated Buklhead demos
- Introduced `AsyncBulkheadDemo` abstract class to extract some common stuff

# Open Questions
- Should we rename the demos to `ConcurrentLimiter` instead of `Bulkhead`?
- In the migrated demo 01 the comment from line 34 till line 35 does not make much sense for me. Do we want to keep it?