### PR TITLE
Clean up Polly.Demos project's sync and async demos

### DIFF
--- a/PollyDemos/Async/AsyncConcurrencyLimiterDemo.cs
+++ b/PollyDemos/Async/AsyncConcurrencyLimiterDemo.cs
@@ -4,12 +4,12 @@ namespace PollyDemos.Async
     {
         // Track the number of 'good' and 'faulting' requests made, succeeded and failed.
         // At any time, requests pending = made - succeeded - failed.
-        protected int goodRequestsMade;
-        protected int goodRequestsSucceeded;
-        protected int goodRequestsFailed;
-        protected int faultingRequestsMade;
-        protected int faultingRequestsSucceeded;
-        protected int faultingRequestsFailed;
+        protected int GoodRequestsMade;
+        protected int GoodRequestsSucceeded;
+        protected int GoodRequestsFailed;
+        protected int FaultingRequestsMade;
+        protected int FaultingRequestsSucceeded;
+        protected int FaultingRequestsFailed;
 
         protected async Task<string> IssueFaultingRequestAndProcessResponseAsync(HttpClient client, CancellationToken cancellationToken)
             => await IssueRequestAndProcessResponseAsync(client, "nonthrottledfaulting", cancellationToken);
@@ -20,7 +20,7 @@ namespace PollyDemos.Async
         private async Task<string> IssueRequestAndProcessResponseAsync(HttpClient client, string route, CancellationToken cancellationToken)
         {
             var response = await client
-                .GetAsync($"{Configuration.WEB_API_ROOT}/api/{route}/{totalRequests}", cancellationToken)
+                .GetAsync($"{Configuration.WEB_API_ROOT}/api/{route}/{TotalRequests}", cancellationToken)
                 .ConfigureAwait(false);
             var responseBody = await response.Content
                 .ReadAsStringAsync(cancellationToken)

--- a/PollyDemos/Async/AsyncDemo.cs
+++ b/PollyDemos/Async/AsyncDemo.cs
@@ -7,6 +7,6 @@ namespace PollyDemos.Async
         public abstract Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress);
 
         public async Task<string> IssueRequestAndProcessResponseAsync(HttpClient client, CancellationToken cancellationToken)
-            => await client.GetStringAsync($"{Configuration.WEB_API_ROOT}/api/values/{totalRequests}", cancellationToken);
+            => await client.GetStringAsync($"{Configuration.WEB_API_ROOT}/api/values/{TotalRequests}", cancellationToken);
     }
 }

--- a/PollyDemos/Async/AsyncDemo00_NoStrategy.cs
+++ b/PollyDemos/Async/AsyncDemo00_NoStrategy.cs
@@ -16,14 +16,11 @@ namespace PollyDemos.Async
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is configured to fail after 3 requests in 5 seconds.
+            EventualSuccesses = 0;
+            EventualFailures = 0;
+            TotalRequests = 0;
 
-            eventualSuccesses = 0;
-            eventualFailures = 0;
-            totalRequests = 0;
-
-            PrintHeader(progress, nameof(AsyncDemo00_NoStrategy));
+            PrintHeader(progress);
 
             var client = new HttpClient();
             var internalCancel = false;
@@ -31,7 +28,7 @@ namespace PollyDemos.Async
             // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
 
                 try
                 {
@@ -40,12 +37,12 @@ namespace PollyDemos.Async
 
                     // Display the response message on the console
                     progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
-                    eventualSuccesses++;
+                    EventualSuccesses++;
                 }
                 catch (Exception e)
                 {
-                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
-                    eventualFailures++;
+                    progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                    EventualFailures++;
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationToken);
@@ -55,10 +52,10 @@ namespace PollyDemos.Async
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
-            new("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
+            new("Requests which eventually failed", EventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Async/AsyncDemo01_RetryNTimes.cs
+++ b/PollyDemos/Async/AsyncDemo01_RetryNTimes.cs
@@ -19,15 +19,12 @@ namespace PollyDemos.Async
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is configured to fail after 3 requests in 5 seconds.
+            EventualSuccesses = 0;
+            Retries = 0;
+            EventualFailures = 0;
+            TotalRequests = 0;
 
-            eventualSuccesses = 0;
-            retries = 0;
-            eventualFailures = 0;
-            totalRequests = 0;
-
-            PrintHeader(progress, nameof(AsyncDemo01_RetryNTimes));
+            PrintHeader(progress);
 
             // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()
@@ -42,7 +39,7 @@ namespace PollyDemos.Async
 
                     // Tell the user what happened
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             }).Build();
@@ -50,10 +47,9 @@ namespace PollyDemos.Async
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
 
                 try
                 {
@@ -65,14 +61,14 @@ namespace PollyDemos.Async
 
                         var responseBody = await IssueRequestAndProcessResponseAsync(client, token);
                         progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
-                        eventualSuccesses++;
+                        EventualSuccesses++;
 
                     }, cancellationToken);
                 }
                 catch (Exception e)
                 {
-                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
-                    eventualFailures++;
+                    progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                    EventualFailures++;
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationToken);
@@ -82,10 +78,10 @@ namespace PollyDemos.Async
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
-            new("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
+            new("Requests which eventually failed", EventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Async/AsyncDemo02_WaitAndRetryNTimes.cs
+++ b/PollyDemos/Async/AsyncDemo02_WaitAndRetryNTimes.cs
@@ -20,17 +20,13 @@ namespace PollyDemos.Async
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is configured to fail after 3 requests in 5 seconds.
+            EventualSuccesses = 0;
+            Retries = 0;
+            EventualFailures = 0;
+            TotalRequests = 0;
 
-            eventualSuccesses = 0;
-            retries = 0;
-            eventualFailures = 0;
-            totalRequests = 0;
+            PrintHeader(progress);
 
-            PrintHeader(progress, nameof(AsyncDemo02_WaitAndRetryNTimes));
-
-            // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()
             {
                 ShouldHandle = new PredicateBuilder().Handle<Exception>(),
@@ -40,7 +36,7 @@ namespace PollyDemos.Async
                 {
                     var exception = args.Outcome.Exception!;
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             }).Build();
@@ -49,29 +45,24 @@ namespace PollyDemos.Async
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
 
                 try
                 {
-                    // Retry the following call according to the strategy.
-                    // The cancellationToken passed in to ExecuteAsync() enables the strategy to cancel retries when the token is signalled.
                     await strategy.ExecuteAsync(async token =>
                     {
-                        // This code is executed within the strategy
-
                         var responseBody = await IssueRequestAndProcessResponseAsync(client, token);
                         progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
-                        eventualSuccesses++;
+                        EventualSuccesses++;
 
                     }, cancellationToken);
                 }
                 catch (Exception e)
                 {
-                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
-                    eventualFailures++;
+                    progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                    EventualFailures++;
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationToken);
@@ -81,10 +72,10 @@ namespace PollyDemos.Async
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
-            new("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
+            new("Requests which eventually failed", EventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Async/AsyncDemo03_WaitAndRetryNTimes_WithEnoughRetries.cs
+++ b/PollyDemos/Async/AsyncDemo03_WaitAndRetryNTimes_WithEnoughRetries.cs
@@ -20,17 +20,13 @@ namespace PollyDemos.Async
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is configured to fail after 3 requests in 5 seconds.
+            EventualSuccesses = 0;
+            Retries = 0;
+            EventualFailures = 0;
+            TotalRequests = 0;
 
-            eventualSuccesses = 0;
-            retries = 0;
-            eventualFailures = 0;
-            totalRequests = 0;
+            PrintHeader(progress);
 
-            PrintHeader(progress, nameof(AsyncDemo03_WaitAndRetryNTimes_WithEnoughRetries));
-
-            // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()
             {
                 ShouldHandle = new PredicateBuilder().Handle<Exception>(),
@@ -40,7 +36,7 @@ namespace PollyDemos.Async
                 {
                     var exception = args.Outcome.Exception!;
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             }).Build();
@@ -48,29 +44,24 @@ namespace PollyDemos.Async
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
 
                 try
                 {
-                    // Retry the following call according to the strategy.
-                    // The cancellationToken passed in to ExecuteAsync() enables the strategy to cancel retries when the token is signalled.
                     await strategy.ExecuteAsync(async token =>
                     {
-                        // This code is executed within the strategy
-
                         var responseBody = await IssueRequestAndProcessResponseAsync(client, token);
                         progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
-                        eventualSuccesses++;
+                        EventualSuccesses++;
 
                     }, cancellationToken);
                 }
                 catch (Exception e)
                 {
-                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
-                    eventualFailures++;
+                    progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                    EventualFailures++;
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationToken);
@@ -80,10 +71,10 @@ namespace PollyDemos.Async
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
-            new("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
+            new("Requests which eventually failed", EventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Async/AsyncDemo04_WaitAndRetryForever.cs
+++ b/PollyDemos/Async/AsyncDemo04_WaitAndRetryForever.cs
@@ -22,17 +22,13 @@ namespace PollyDemos.Async
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is configured to fail after 3 requests in 5 seconds.
+            EventualSuccesses = 0;
+            Retries = 0;
+            EventualFailures = 0;
+            TotalRequests = 0;
 
-            eventualSuccesses = 0;
-            retries = 0;
-            eventualFailures = 0;
-            totalRequests = 0;
+            PrintHeader(progress);
 
-            PrintHeader(progress, nameof(AsyncDemo04_WaitAndRetryForever));
-
-            // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()
             {
                 ShouldHandle = new PredicateBuilder().Handle<Exception>(),
@@ -42,7 +38,7 @@ namespace PollyDemos.Async
                 {
                     var exception = args.Outcome.Exception!;
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             }).Build();
@@ -50,29 +46,24 @@ namespace PollyDemos.Async
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
 
                 try
                 {
-                    // Retry the following call according to the strategy.
-                    // The cancellationToken passed in to ExecuteAsync() enables the strategy to cancel retries when the token is signalled.
                     await strategy.ExecuteAsync(async token =>
                     {
-                        // This code is executed within the strategy
-
                         var responseBody = await IssueRequestAndProcessResponseAsync(client, token);
                         progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
-                        eventualSuccesses++;
+                        EventualSuccesses++;
 
                     }, cancellationToken);
                 }
                 catch (Exception e)
                 {
-                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
-                    eventualFailures++;
+                    progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                    EventualFailures++;
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationToken);
@@ -82,10 +73,10 @@ namespace PollyDemos.Async
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
-            new("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
+            new("Requests which eventually failed", EventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Async/AsyncDemo05_WaitAndRetryWithExponentialBackoff.cs
+++ b/PollyDemos/Async/AsyncDemo05_WaitAndRetryWithExponentialBackoff.cs
@@ -24,28 +24,24 @@ namespace PollyDemos.Async
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is configured to fail after 3 requests in 5 seconds.
+            EventualSuccesses = 0;
+            Retries = 0;
+            EventualFailures = 0;
+            TotalRequests = 0;
 
-            eventualSuccesses = 0;
-            retries = 0;
-            eventualFailures = 0;
-            totalRequests = 0;
+            PrintHeader(progress);
 
-            PrintHeader(progress, nameof(AsyncDemo05_WaitAndRetryWithExponentialBackoff));
-
-            // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()
             {
                 ShouldHandle = new PredicateBuilder().Handle<Exception>(),
                 MaxRetryAttempts = 6, // We could also retry indefinitely by using int.MaxValue
-                BackoffType = DelayBackoffType.Exponential,
+                BackoffType = DelayBackoffType.Exponential, // Back off: 1s, 2s, 4s, 8s, ... + jitter
                 OnRetry = args =>
                 {
                     var exception = args.Outcome.Exception!;
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
                     progress.Report(ProgressWithMessage($" ... automatically delaying for {args.RetryDelay.TotalMilliseconds}ms.", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             }).Build();
@@ -53,29 +49,24 @@ namespace PollyDemos.Async
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
 
                 try
                 {
-                    // Retry the following call according to the strategy.
-                    // The cancellationToken passed in to ExecuteAsync() enables the strategy to cancel retries when the token is signalled.
                     await strategy.ExecuteAsync(async token =>
                     {
-                        // This code is executed within the strategy
-
                         var responseBody = await IssueRequestAndProcessResponseAsync(client, token);
                         progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
-                        eventualSuccesses++;
+                        EventualSuccesses++;
 
                     }, cancellationToken);
                 }
                 catch (Exception e)
                 {
-                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
-                    eventualFailures++;
+                    progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                    EventualFailures++;
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationToken);
@@ -85,10 +76,10 @@ namespace PollyDemos.Async
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
-            new("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
+            new("Requests which eventually failed", EventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Async/AsyncDemo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs
+++ b/PollyDemos/Async/AsyncDemo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs
@@ -29,16 +29,13 @@ namespace PollyDemos.Async
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is configured to fail after 3 requests in 5 seconds.
-
-            eventualSuccesses = 0;
-            retries = 0;
+            EventualSuccesses = 0;
+            Retries = 0;
             eventualFailuresDueToTimeout = 0;
             eventualFailuresForOtherReasons = 0;
-            totalRequests = 0;
+            TotalRequests = 0;
 
-            PrintHeader(progress, nameof(AsyncDemo09_Pipeline_Fallback_Timeout_WaitAndRetry));
+            PrintHeader(progress);
 
             Stopwatch? watch = null;
             var pipelineBuilder = new ResiliencePipelineBuilder<string>();
@@ -65,7 +62,7 @@ namespace PollyDemos.Async
                 {
                     var exception = args.Outcome.Exception!;
                     progress.Report(ProgressWithMessage($".Log,then retry: {exception.Message}", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             });
@@ -112,21 +109,18 @@ namespace PollyDemos.Async
 
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
                 watch = Stopwatch.StartNew();
 
                 try
                 {
-                    // Manage the call according to the pipeline.
                     var responseBody = await pipeline.ExecuteAsync(async token =>
                         await IssueRequestAndProcessResponseAsync(client, token), cancellationToken);
 
                     watch.Stop();
                     progress.Report(ProgressWithMessage($"Response: {responseBody}(after {watch.ElapsedMilliseconds}ms)", Color.Green));
-                    eventualSuccesses++;
+                    EventualSuccesses++;
                 }
-                // This try-catch is not needed, since we have a Fallback for any Exceptions.
-                // It's only been left in to *demonstrate* it should never get hit.
                 catch (Exception e)
                 {
                     var errorMessage = "Should never arrive here. Use of fallback for any Exception should have provided nice fallback value for exceptions.";
@@ -140,9 +134,9 @@ namespace PollyDemos.Async
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
             new("Requests timed out by timeout policy", eventualFailuresDueToTimeout, Color.Magenta),
             new("Requests which failed after longer delay", eventualFailuresForOtherReasons, Color.Red),
         };

--- a/PollyDemos/Async/AsyncDemo11_MultipleConcurrencyLimiters.cs
+++ b/PollyDemos/Async/AsyncDemo11_MultipleConcurrencyLimiters.cs
@@ -32,8 +32,7 @@ namespace PollyDemos.Async
                 queueLimit: 10)
             .Build();
 
-        private readonly ResiliencePipeline limiterForFaultingCalls =
-            new ResiliencePipelineBuilder()
+        private readonly ResiliencePipeline limiterForFaultingCalls = new ResiliencePipelineBuilder()
             .AddConcurrencyLimiter(
                 permitLimit: callerParallelCapacity / 2,
                 queueLimit: 10)
@@ -46,10 +45,10 @@ namespace PollyDemos.Async
         {
             ArgumentNullException.ThrowIfNull(nameof(progress));
 
-            PrintHeader(progress, nameof(AsyncDemo11_MultipleConcurrencyLimiters));
-            totalRequests = 0;
+            PrintHeader(progress);
+            TotalRequests = 0;
 
-            await Task.FromResult(true).ConfigureAwait(false); // Ensure none of what follows runs synchronously.
+            await ValueTask.FromResult(true);
 
             var tasks = new List<Task>();
             var internalCancellationTokenSource = new CancellationTokenSource();
@@ -63,32 +62,28 @@ namespace PollyDemos.Async
 
             while (!(internalCancel || externalCancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
-                var thisRequest = totalRequests;
+                TotalRequests++;
+                var thisRequest = TotalRequests;
 
-                // Randomly make either 'good' or 'faulting' calls.
                 if (Random.Shared.Next(0, 2) == 0)
                 {
-                    goodRequestsMade++;
+                    GoodRequestsMade++;
                     tasks.Add(CallGoodEndpoint(client, messages, thisRequest, combinedToken));
                 }
                 else
                 {
-                    faultingRequestsMade++;
+                    FaultingRequestsMade++;
                     tasks.Add(CallFaultingEndpoint(client, messages, thisRequest, combinedToken));
                 }
 
                 AddSummary(messages);
 
-                // Output all messages available right now.
                 while (messages.TryDequeue(out var tuple))
                 {
                     progress.Report(ProgressWithMessage(tuple.Message, tuple.Color));
                 }
 
-                // Wait briefly
                 await Task.Delay(TimeSpan.FromSeconds(0.2), externalCancellationToken).ConfigureAwait(false);
-                // Support cancellation by keyboard, when called from a console; ignore exceptions, if console not accessible.
                 try
                 {
                     internalCancel = Console.KeyAvailable;
@@ -101,23 +96,23 @@ namespace PollyDemos.Async
 
         private void AddSummary(ConcurrentQueue<(string Message, Color Color)> messages)
         {
-            messages.Enqueue(($"Total requests: requested {totalRequests:00}, ", Color.White));
-            messages.Enqueue(($"Good endpoint: requested {goodRequestsMade:00}, ", Color.White));
-            messages.Enqueue(($"Good endpoint:succeeded {goodRequestsSucceeded:00}, ", Color.Green));
-            messages.Enqueue(($"Good endpoint:pending {goodRequestsMade - goodRequestsSucceeded - goodRequestsFailed:00}, ", Color.Yellow));
-            messages.Enqueue(($"Good endpoint:failed {goodRequestsFailed:00}.", Color.Red));
+            messages.Enqueue(($"Total requests: requested {TotalRequests:00}, ", Color.White));
+            messages.Enqueue(($"Good endpoint: requested {GoodRequestsMade:00}, ", Color.White));
+            messages.Enqueue(($"Good endpoint:succeeded {GoodRequestsSucceeded:00}, ", Color.Green));
+            messages.Enqueue(($"Good endpoint:pending {GoodRequestsMade - GoodRequestsSucceeded - GoodRequestsFailed:00}, ", Color.Yellow));
+            messages.Enqueue(($"Good endpoint:failed {GoodRequestsFailed:00}.", Color.Red));
             messages.Enqueue((string.Empty, Color.Default));
 
-            messages.Enqueue(($"Faulting endpoint: requested {faultingRequestsMade:00}, ", Color.White));
-            messages.Enqueue(($"Faulting endpoint:succeeded {faultingRequestsSucceeded:00}, ", Color.Green));
-            messages.Enqueue(($"Faulting endpoint:pending {faultingRequestsMade - faultingRequestsSucceeded - faultingRequestsFailed:00}, ", Color.Yellow));
-            messages.Enqueue(($"Faulting endpoint:failed {faultingRequestsFailed:00}.", Color.Red));
+            messages.Enqueue(($"Faulting endpoint: requested {FaultingRequestsMade:00}, ", Color.White));
+            messages.Enqueue(($"Faulting endpoint:succeeded {FaultingRequestsSucceeded:00}, ", Color.Green));
+            messages.Enqueue(($"Faulting endpoint:pending {FaultingRequestsMade - FaultingRequestsSucceeded - FaultingRequestsFailed:00}, ", Color.Yellow));
+            messages.Enqueue(($"Faulting endpoint:failed {FaultingRequestsFailed:00}.", Color.Red));
             messages.Enqueue((string.Empty, Color.Default));
         }
 
         private Task CallFaultingEndpoint(HttpClient client, ConcurrentQueue<(string Message, Color Color)> messages, int thisRequest, CancellationToken cancellationToken)
         {
-            ValueTask issueRequest = limiterForGoodCalls.ExecuteAsync(async token =>
+            ValueTask issueRequest = limiterForFaultingCalls.ExecuteAsync(async token =>
             {
                 try
                 {
@@ -127,7 +122,7 @@ namespace PollyDemos.Async
                     {
                         messages.Enqueue(($"Response: {responseBody}", Color.Green));
                     }
-                    faultingRequestsSucceeded++;
+                    FaultingRequestsSucceeded++;
                 }
                 catch (Exception e)
                 {
@@ -135,7 +130,7 @@ namespace PollyDemos.Async
                     {
                         messages.Enqueue(($"Request {thisRequest} eventually failed with: {e.Message}", Color.Red));
                     }
-                    faultingRequestsFailed++;
+                    FaultingRequestsFailed++;
                 }
             }, cancellationToken);
 
@@ -148,7 +143,7 @@ namespace PollyDemos.Async
                         var message = $"Request {state} failed with: {failedTask.Exception!.Flatten().InnerExceptions.First().Message}";
                         messages.Enqueue((message, Color.Red));
                     }
-                    faultingRequestsFailed++;
+                    FaultingRequestsFailed++;
                 }, thisRequest, TaskContinuationOptions.NotOnRanToCompletion);
 
             return handleFailure;
@@ -166,7 +161,7 @@ namespace PollyDemos.Async
                     {
                         messages.Enqueue(($"Response: {responseBody}", Color.Green));
                     }
-                    goodRequestsSucceeded++;
+                    GoodRequestsSucceeded++;
                 }
                 catch (Exception e)
                 {
@@ -174,7 +169,7 @@ namespace PollyDemos.Async
                     {
                         messages.Enqueue(($"Request {thisRequest} eventually failed with: {e.Message}", Color.Red));
                     }
-                    goodRequestsFailed++;
+                    GoodRequestsFailed++;
                 }
             }, cancellationToken);
 
@@ -187,7 +182,7 @@ namespace PollyDemos.Async
                         var message = $"Request {state} failed with: {failedTask.Exception!.Flatten().InnerExceptions.First().Message}";
                         messages.Enqueue((message, Color.Red));
                     }
-                    goodRequestsFailed++;
+                    GoodRequestsFailed++;
                 }, thisRequest, TaskContinuationOptions.NotOnRanToCompletion);
 
             return handleFailure;
@@ -195,15 +190,15 @@ namespace PollyDemos.Async
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests, Color.Default),
-            new("Good endpoint: requested", goodRequestsMade, Color.Default),
-            new("Good endpoint: succeeded", goodRequestsSucceeded, Color.Green),
-            new("Good endpoint: pending", goodRequestsMade - goodRequestsSucceeded - goodRequestsFailed, Color.Yellow),
-            new("Good endpoint: failed", goodRequestsFailed, Color.Red),
-            new("Faulting endpoint: requested", faultingRequestsMade, Color.Default),
-            new("Faulting endpoint: succeeded", faultingRequestsSucceeded, Color.Green),
-            new("Faulting endpoint: pending", faultingRequestsMade - faultingRequestsSucceeded - faultingRequestsFailed, Color.Yellow),
-            new("Faulting endpoint: failed", faultingRequestsFailed, Color.Red),
+            new("Total requests made", TotalRequests, Color.Default),
+            new("Good endpoint: requested", GoodRequestsMade, Color.Default),
+            new("Good endpoint: succeeded", GoodRequestsSucceeded, Color.Green),
+            new("Good endpoint: pending", GoodRequestsMade - GoodRequestsSucceeded - GoodRequestsFailed, Color.Yellow),
+            new("Good endpoint: failed", GoodRequestsFailed, Color.Red),
+            new("Faulting endpoint: requested", FaultingRequestsMade, Color.Default),
+            new("Faulting endpoint: succeeded", FaultingRequestsSucceeded, Color.Green),
+            new("Faulting endpoint: pending", FaultingRequestsMade - FaultingRequestsSucceeded - FaultingRequestsFailed, Color.Yellow),
+            new("Faulting endpoint: failed", FaultingRequestsFailed, Color.Red),
         };
     }
 }

--- a/PollyDemos/DemoBase.cs
+++ b/PollyDemos/DemoBase.cs
@@ -4,10 +4,10 @@ namespace PollyDemos
 {
     public abstract class DemoBase
     {
-        protected int totalRequests;
-        protected int eventualSuccesses;
-        protected int eventualFailures;
-        protected int retries;
+        protected int TotalRequests;
+        protected int EventualSuccesses;
+        protected int EventualFailures;
+        protected int Retries;
 
         protected bool TerminateDemosByKeyPress { get; } = true;
 
@@ -24,9 +24,9 @@ namespace PollyDemos
         public DemoProgress ProgressWithMessages(IEnumerable<ColoredMessage> messages)
             => new (LatestStatistics, messages);
 
-        public void PrintHeader(IProgress<DemoProgress> progress, string demoName)
+        public void PrintHeader(IProgress<DemoProgress> progress)
         {
-            progress.Report(ProgressWithMessage(demoName));
+            progress.Report(ProgressWithMessage(GetType().Name));
             progress.Report(ProgressWithMessage("======"));
             progress.Report(ProgressWithMessage(string.Empty));
         }

--- a/PollyDemos/Sync/Demo00_NoStrategy.cs
+++ b/PollyDemos/Sync/Demo00_NoStrategy.cs
@@ -16,14 +16,11 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
+            EventualSuccesses = 0;
+            EventualFailures = 0;
+            TotalRequests = 0;
 
-            eventualSuccesses = 0;
-            eventualFailures = 0;
-            totalRequests = 0;
-
-            PrintHeader(progress, nameof(Demo00_NoStrategy));
+            PrintHeader(progress);
 
             var client = new HttpClient();
             var internalCancel = false;
@@ -31,18 +28,18 @@ namespace PollyDemos.Sync
             // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
 
                 try
                 {
                     var responseBody = IssueRequestAndProcessResponse(client);
                     progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
-                    eventualSuccesses++;
+                    EventualSuccesses++;
                 }
                 catch (Exception e)
                 {
-                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
-                    eventualFailures++;
+                    progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                    EventualFailures++;
                 }
 
                 Thread.Sleep(500);
@@ -52,10 +49,10 @@ namespace PollyDemos.Sync
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
             new("Retries made to help achieve success", 0, Color.Yellow),
-            new("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Requests which eventually failed", EventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Sync/Demo01_RetryNTimes.cs
+++ b/PollyDemos/Sync/Demo01_RetryNTimes.cs
@@ -19,15 +19,12 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
+            EventualSuccesses = 0;
+            Retries = 0;
+            EventualFailures = 0;
+            TotalRequests = 0;
 
-            eventualSuccesses = 0;
-            retries = 0;
-            eventualFailures = 0;
-            totalRequests = 0;
-
-            PrintHeader(progress, nameof(Demo01_RetryNTimes));
+            PrintHeader(progress);
 
             // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()
@@ -42,7 +39,7 @@ namespace PollyDemos.Sync
 
                     // Tell the user what happened
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             }).Build();
@@ -50,10 +47,9 @@ namespace PollyDemos.Sync
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
 
                 try
                 {
@@ -65,14 +61,14 @@ namespace PollyDemos.Sync
 
                         var responseBody = IssueRequestAndProcessResponse(client, token);
                         progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
-                        eventualSuccesses++;
+                        EventualSuccesses++;
 
                     }, cancellationToken);
                 }
                 catch (Exception e)
                 {
-                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
-                    eventualFailures++;
+                    progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                    EventualFailures++;
                 }
 
                 Thread.Sleep(500);
@@ -82,10 +78,10 @@ namespace PollyDemos.Sync
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
-            new("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
+            new("Requests which eventually failed", EventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Sync/Demo02_WaitAndRetryNTimes.cs
+++ b/PollyDemos/Sync/Demo02_WaitAndRetryNTimes.cs
@@ -20,17 +20,13 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
+            EventualSuccesses = 0;
+            Retries = 0;
+            EventualFailures = 0;
+            TotalRequests = 0;
 
-            eventualSuccesses = 0;
-            retries = 0;
-            eventualFailures = 0;
-            totalRequests = 0;
+            PrintHeader(progress);
 
-            PrintHeader(progress, nameof(Demo02_WaitAndRetryNTimes));
-
-            // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()
             {
                 ShouldHandle = new PredicateBuilder().Handle<Exception>(),
@@ -40,7 +36,7 @@ namespace PollyDemos.Sync
                 {
                     var exception = args.Outcome.Exception!;
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             }).Build();
@@ -48,29 +44,24 @@ namespace PollyDemos.Sync
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
 
                 try
                 {
-                    // Retry the following call according to the strategy.
-                    // The cancellationToken passed in to Execute() enables the strategy to cancel retries, when the token is signalled.
                     strategy.Execute(token =>
                     {
-                        // This code is executed within the strategy
-
                         var responseBody = IssueRequestAndProcessResponse(client, token);
                         progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
-                        eventualSuccesses++;
+                        EventualSuccesses++;
 
                     }, cancellationToken);
                 }
                 catch (Exception e)
                 {
-                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
-                    eventualFailures++;
+                    progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                    EventualFailures++;
                 }
 
                 Thread.Sleep(500);
@@ -80,10 +71,10 @@ namespace PollyDemos.Sync
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
-            new("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
+            new("Requests which eventually failed", EventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Sync/Demo03_WaitAndRetryNTimes_WithEnoughRetries.cs
+++ b/PollyDemos/Sync/Demo03_WaitAndRetryNTimes_WithEnoughRetries.cs
@@ -20,17 +20,13 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
+            EventualSuccesses = 0;
+            Retries = 0;
+            EventualFailures = 0;
+            TotalRequests = 0;
 
-            eventualSuccesses = 0;
-            retries = 0;
-            eventualFailures = 0;
-            totalRequests = 0;
+            PrintHeader(progress);
 
-            PrintHeader(progress, nameof(Demo03_WaitAndRetryNTimes_WithEnoughRetries));
-
-            // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()
             {
                 ShouldHandle = new PredicateBuilder().Handle<Exception>(),
@@ -40,7 +36,7 @@ namespace PollyDemos.Sync
                 {
                     var exception = args.Outcome.Exception!;
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             }).Build();
@@ -48,29 +44,24 @@ namespace PollyDemos.Sync
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
 
                 try
                 {
-                    // Retry the following call according to the strategy.
-                    // The cancellationToken passed in to Execute() enables the strategy to cancel retries, when the token is signalled.
                     strategy.Execute(token =>
                     {
-                        // This code is executed within the strategy
-
                         var responseBody = IssueRequestAndProcessResponse(client, token);
                         progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
-                        eventualSuccesses++;
+                        EventualSuccesses++;
 
                     }, cancellationToken);
                 }
                 catch (Exception e)
                 {
-                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
-                    eventualFailures++;
+                    progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                    EventualFailures++;
                 }
 
                 Thread.Sleep(500);
@@ -80,10 +71,10 @@ namespace PollyDemos.Sync
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
-            new("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
+            new("Requests which eventually failed", EventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Sync/Demo05_WaitAndRetryWithExponentialBackoff.cs
+++ b/PollyDemos/Sync/Demo05_WaitAndRetryWithExponentialBackoff.cs
@@ -24,28 +24,24 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
+            EventualSuccesses = 0;
+            Retries = 0;
+            EventualFailures = 0;
+            TotalRequests = 0;
 
-            eventualSuccesses = 0;
-            retries = 0;
-            eventualFailures = 0;
-            totalRequests = 0;
+            PrintHeader(progress);
 
-            PrintHeader(progress, nameof(Demo05_WaitAndRetryWithExponentialBackoff));
-
-            // Define our strategy:
             var strategy = new ResiliencePipelineBuilder().AddRetry(new()
             {
                 ShouldHandle = new PredicateBuilder().Handle<Exception>(),
-                MaxRetryAttempts = 6, // We could also retry indefinitely, but chose six times instead.
-                BackoffType = DelayBackoffType.Exponential,
+                MaxRetryAttempts = 6, // We could also retry indefinitely by using int.MaxValue
+                BackoffType = DelayBackoffType.Exponential, // Back off: 1s, 2s, 4s, 8s, ... + jitter
                 OnRetry = args =>
                 {
                     var exception = args.Outcome.Exception!;
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
                     progress.Report(ProgressWithMessage($" ... automatically delaying for {args.RetryDelay.TotalMilliseconds}ms.", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             }).Build();
@@ -53,29 +49,24 @@ namespace PollyDemos.Sync
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
 
                 try
                 {
-                    // Retry the following call according to the strategy.
-                    // The cancellationToken passed in to Execute() enables the strategy to cancel retries, when the token is signalled.
                     strategy.Execute(token =>
                     {
-                        // This code is executed within the strategy
-
                         var responseBody = IssueRequestAndProcessResponse(client, token);
                         progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
-                        eventualSuccesses++;
+                        EventualSuccesses++;
 
                     }, cancellationToken);
                 }
                 catch (Exception e)
                 {
-                    progress.Report(ProgressWithMessage($"Request {totalRequests} eventually failed with: {e.Message}", Color.Red));
-                    eventualFailures++;
+                    progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                    EventualFailures++;
                 }
 
                 Thread.Sleep(500);
@@ -85,10 +76,10 @@ namespace PollyDemos.Sync
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
-            new("Requests which eventually failed", eventualFailures, Color.Red),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
+            new("Requests which eventually failed", EventualFailures, Color.Red),
         };
     }
 }

--- a/PollyDemos/Sync/Demo06_WaitAndRetryNestingCircuitBreaker.cs
+++ b/PollyDemos/Sync/Demo06_WaitAndRetryNestingCircuitBreaker.cs
@@ -35,18 +35,14 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
-
-            eventualSuccesses = 0;
-            retries = 0;
+            EventualSuccesses = 0;
+            Retries = 0;
             eventualFailuresDueToCircuitBreaking = 0;
             eventualFailuresForOtherReasons = 0;
-            totalRequests = 0;
+            TotalRequests = 0;
 
-            PrintHeader(progress, nameof(Demo06_WaitAndRetryNestingCircuitBreaker));
+            PrintHeader(progress);
 
-            // Define our retry strategy:
             var retryStrategy = new ResiliencePipelineBuilder().AddRetry(new()
             {
                 // Exception filtering - we don't retry if the inner circuit-breaker judges the underlying system is out of commission.
@@ -57,7 +53,7 @@ namespace PollyDemos.Sync
                 {
                     var exception = args.Outcome.Exception!;
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             }).Build();
@@ -94,10 +90,9 @@ namespace PollyDemos.Sync
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
                 var watch = Stopwatch.StartNew();
 
                 try
@@ -116,24 +111,22 @@ namespace PollyDemos.Sync
                         }, outerToken);
 
                         watch.Stop();
-
-                        // Display the response message on the console
                         progress.Report(ProgressWithMessage($"Response : {responseBody} (after {watch.ElapsedMilliseconds}ms)", Color.Green));
-                        eventualSuccesses++;
+                        EventualSuccesses++;
 
                     }, cancellationToken);
                 }
                 catch (BrokenCircuitException bce)
                 {
                     watch.Stop();
-                    var logMessage = $"Request {totalRequests} failed with: {bce.GetType().Name} (after {watch.ElapsedMilliseconds}ms)";
+                    var logMessage = $"Request {TotalRequests} failed with: {bce.GetType().Name} (after {watch.ElapsedMilliseconds}ms)";
                     progress.Report(ProgressWithMessage(logMessage,Color.Red));
                     eventualFailuresDueToCircuitBreaking++;
                 }
                 catch (Exception e)
                 {
                     watch.Stop();
-                    var logMessage = $"Request {totalRequests} eventually failed with: {e.Message} (after {watch.ElapsedMilliseconds}ms)";
+                    var logMessage = $"Request {TotalRequests} eventually failed with: {e.Message} (after {watch.ElapsedMilliseconds}ms)";
                     progress.Report(ProgressWithMessage(logMessage,Color.Red));
                     eventualFailuresForOtherReasons++;
                 }
@@ -145,9 +138,9 @@ namespace PollyDemos.Sync
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
             new("Requests failed early by broken circuit", eventualFailuresDueToCircuitBreaking, Color.Magenta),
             new("Requests which failed after longer delay", eventualFailuresForOtherReasons, Color.Red),
         };

--- a/PollyDemos/Sync/Demo07_WaitAndRetryNestingCircuitBreakerUsingPipeline.cs
+++ b/PollyDemos/Sync/Demo07_WaitAndRetryNestingCircuitBreakerUsingPipeline.cs
@@ -27,25 +27,21 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
-
-            eventualSuccesses = 0;
-            retries = 0;
+            EventualSuccesses = 0;
+            Retries = 0;
             eventualFailuresDueToCircuitBreaking = 0;
             eventualFailuresForOtherReasons = 0;
-            totalRequests = 0;
+            TotalRequests = 0;
 
-            PrintHeader(progress, nameof(Demo07_WaitAndRetryNestingCircuitBreakerUsingPipeline));
+            PrintHeader(progress);
 
-            // New for demo07: here we define a pipeline builder which will be used to compose strategies incrementally.
+            // Define a pipeline builder which will be used to compose strategies incrementally.
             var pipelineBuilder = new ResiliencePipelineBuilder();
 
-            // New for demo07: the order of strategy definitions has changed.
+            // The order of strategy definitions has changed.
             // Circuit breaker comes first because that will be the inner strategy.
             // Retry comes second because that will be the outer strategy.
 
-            // Define our circuit breaker strategy:
             pipelineBuilder.AddCircuitBreaker(new()
             {
                 ShouldHandle = new PredicateBuilder().Handle<Exception>(),
@@ -72,34 +68,31 @@ namespace PollyDemos.Sync
                     progress.Report(ProgressWithMessage(".Breaker logging: Half-open: Next call is a trial!", Color.Magenta));
                     return default;
                 }
-            }); // New for demo07: here we are not calling the Build method because we want to add one more strategy to the pipeline.
+            }); // We are not calling the Build method because we want to add one more strategy to the pipeline.
 
-            // Define our retry strategy:
             pipelineBuilder.AddRetry(new()
             {
-                // Exception filtering - we don't retry if the inner circuit-breaker judges the underlying system is out of commission.
                 ShouldHandle = new PredicateBuilder().Handle<Exception>(ex => ex is not BrokenCircuitException),
-                MaxRetryAttempts = int.MaxValue, // Retry indefinitely
+                MaxRetryAttempts = int.MaxValue,
                 Delay = TimeSpan.FromMilliseconds(200),
                 OnRetry = args =>
                 {
                     var exception = args.Outcome.Exception!;
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
-            }); // New for demo07: here we are not calling the Build method because we will do it as a separate step to make the code cleaner.
+            }); // We are not calling the Build method here because we will do it as a separate step to make the code cleaner.
 
-            // New for demo07: here we build the pipeline since we have added all the necessary strategies to it.
+            // Build the pipeline since we have added all the necessary strategies to it.
             var pipeline = pipelineBuilder.Build();
 
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
                 var watch = Stopwatch.StartNew();
 
                 try
@@ -116,22 +109,20 @@ namespace PollyDemos.Sync
                     }, cancellationToken);
 
                     watch.Stop();
-
-                    // Display the response message on the console
                     progress.Report(ProgressWithMessage($"Response : {responseBody} (after {watch.ElapsedMilliseconds}ms)", Color.Green));
-                    eventualSuccesses++;
+                    EventualSuccesses++;
                 }
                 catch (BrokenCircuitException bce)
                 {
                     watch.Stop();
-                    var logMessage = $"Request {totalRequests} failed with: {bce.GetType().Name} (after {watch.ElapsedMilliseconds}ms)";
+                    var logMessage = $"Request {TotalRequests} failed with: {bce.GetType().Name} (after {watch.ElapsedMilliseconds}ms)";
                     progress.Report(ProgressWithMessage(logMessage, Color.Red));
                     eventualFailuresDueToCircuitBreaking++;
                 }
                 catch (Exception e)
                 {
                     watch.Stop();
-                    var logMessage = $"Request {totalRequests} eventually failed with: {e.Message} (after {watch.ElapsedMilliseconds}ms)";
+                    var logMessage = $"Request {TotalRequests} eventually failed with: {e.Message} (after {watch.ElapsedMilliseconds}ms)";
                     progress.Report(ProgressWithMessage(logMessage, Color.Red));
                     eventualFailuresForOtherReasons++;
                 }
@@ -143,9 +134,9 @@ namespace PollyDemos.Sync
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
             new("Requests failed early by broken circuit", eventualFailuresDueToCircuitBreaking, Color.Magenta),
             new("Requests which failed after longer delay", eventualFailuresForOtherReasons, Color.Red),
         };

--- a/PollyDemos/Sync/Demo08_Pipeline-Fallback-WaitAndRetry-CircuitBreaker.cs
+++ b/PollyDemos/Sync/Demo08_Pipeline-Fallback-WaitAndRetry-CircuitBreaker.cs
@@ -29,26 +29,22 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
-
-            eventualSuccesses = 0;
-            retries = 0;
+            EventualSuccesses = 0;
+            Retries = 0;
             eventualFailuresDueToCircuitBreaking = 0;
             eventualFailuresForOtherReasons = 0;
-            totalRequests = 0;
+            TotalRequests = 0;
 
-            PrintHeader(progress, nameof(Demo08_Pipeline_Fallback_WaitAndRetry_CircuitBreaker));
+            PrintHeader(progress);
 
             Stopwatch? watch = null;
 
-            // New for demo08: we had to provide the return type (string) to be able to use Fallback.
+            // Provide the return type (string) to be able to use Fallback.
             var pipelineBuilder = new ResiliencePipelineBuilder<string>();
 
-            // Define our circuit breaker strategy:
             pipelineBuilder.AddCircuitBreaker(new()
             {
-                // New for demo08: since pipeline has a string type parameter that's why the PredicateBuilder has to have one as well.
+                // Since pipeline has a string type parameter that's why the PredicateBuilder has to have one as well.
                 ShouldHandle = new PredicateBuilder<string>().Handle<Exception>(),
                 FailureRatio = 1.0,
                 MinimumThroughput = 4,
@@ -75,11 +71,9 @@ namespace PollyDemos.Sync
                 }
             });
 
-            // Define our retry strategy:
             pipelineBuilder.AddRetry(new()
             {
-                // New for demo08: since pipeline has a string type parameter that's why the PredicateBuilder has to have one as well.
-                // Exception filtering - we don't retry if the inner circuit-breaker judges the underlying system is out of commission.
+                // Since pipeline has a string type parameter that's why the PredicateBuilder has to have one as well.
                 ShouldHandle = new PredicateBuilder<string>().Handle<Exception>(ex => ex is not BrokenCircuitException),
                 MaxRetryAttempts = int.MaxValue, // Retry indefinitely
                 Delay = TimeSpan.FromMilliseconds(200),
@@ -87,7 +81,7 @@ namespace PollyDemos.Sync
                 {
                     var exception = args.Outcome.Exception!;
                     progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             });
@@ -132,22 +126,18 @@ namespace PollyDemos.Sync
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
                 watch = Stopwatch.StartNew();
 
                 try
                 {
-                    // Manage the call according to the pipeline.
                     var responseBody = pipeline.Execute(token => IssueRequestAndProcessResponse(client, token), cancellationToken);
 
                     watch.Stop();
-
-                    // Display the response message on the console
                     progress.Report(ProgressWithMessage($"Response : {responseBody} (after {watch.ElapsedMilliseconds}ms)", Color.Green));
-                    eventualSuccesses++;
+                    EventualSuccesses++;
                 }
                 // This try-catch is not needed, since we have a Fallback for any Exceptions.
                 // It's only been left in to *demonstrate* it should never get hit.
@@ -164,9 +154,9 @@ namespace PollyDemos.Sync
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
             new("Requests failed early by broken circuit", eventualFailuresDueToCircuitBreaking, Color.Magenta),
             new("Requests which failed after longer delay", eventualFailuresForOtherReasons, Color.Red),
         };

--- a/PollyDemos/Sync/Demo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs
+++ b/PollyDemos/Sync/Demo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs
@@ -29,16 +29,13 @@ namespace PollyDemos.Sync
         {
             ArgumentNullException.ThrowIfNull(progress);
 
-            // Let's call a web API service to make repeated requests to a server.
-            // The service is programmed to fail after 3 requests in 5 seconds.
-
-            eventualSuccesses = 0;
-            retries = 0;
+            EventualSuccesses = 0;
+            Retries = 0;
             eventualFailuresDueToTimeout = 0;
             eventualFailuresForOtherReasons = 0;
-            totalRequests = 0;
+            TotalRequests = 0;
 
-            PrintHeader(progress, nameof(Demo09_Pipeline_Fallback_Timeout_WaitAndRetry));
+            PrintHeader(progress);
 
             Stopwatch? watch = null;
             var pipelineBuilder = new ResiliencePipelineBuilder<string>();
@@ -65,7 +62,7 @@ namespace PollyDemos.Sync
                 {
                     var exception = args.Outcome.Exception!;
                     progress.Report(ProgressWithMessage($".Log,then retry: {exception.Message}", Color.Yellow));
-                    retries++;
+                    Retries++;
                     return default;
                 }
             });
@@ -110,25 +107,19 @@ namespace PollyDemos.Sync
             var client = new HttpClient();
             var internalCancel = false;
 
-            // Do the following until a key is pressed
             while (!(internalCancel || cancellationToken.IsCancellationRequested))
             {
-                totalRequests++;
+                TotalRequests++;
                 watch = Stopwatch.StartNew();
 
                 try
                 {
-                    // Manage the call according to the pipeline.
                     var responseBody = pipeline.Execute(token => IssueRequestAndProcessResponse(client, token), cancellationToken);
 
                     watch.Stop();
-
-                    // Display the response message on the console
                     progress.Report(ProgressWithMessage($"Response : {responseBody} (after {watch.ElapsedMilliseconds}ms)", Color.Green));
-                    eventualSuccesses++;
+                    EventualSuccesses++;
                 }
-                // This try-catch is not needed, since we have a Fallback for any Exceptions.
-                // It's only been left in to *demonstrate* it should never get hit.
                 catch (Exception e)
                 {
                     var errorMessage = "Should never arrive here. Use of fallback for any Exception should have provided nice fallback value for exceptions.";
@@ -142,9 +133,9 @@ namespace PollyDemos.Sync
 
         public override Statistic[] LatestStatistics => new Statistic[]
         {
-            new("Total requests made", totalRequests),
-            new("Requests which eventually succeeded", eventualSuccesses, Color.Green),
-            new("Retries made to help achieve success", retries, Color.Yellow),
+            new("Total requests made", TotalRequests),
+            new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+            new("Retries made to help achieve success", Retries, Color.Yellow),
             new("Requests timed out by timeout strategy", eventualFailuresDueToTimeout, Color.Magenta),
             new("Requests which failed after longer delay", eventualFailuresForOtherReasons, Color.Red),
         };

--- a/PollyDemos/Sync/SyncDemo.cs
+++ b/PollyDemos/Sync/SyncDemo.cs
@@ -9,7 +9,7 @@ namespace PollyDemos.Sync
         protected string IssueRequestAndProcessResponse(HttpClient client, CancellationToken cancellationToken = default)
         {
             // Make a request and get a response
-            var url = $"{Configuration.WEB_API_ROOT}/api/values/{totalRequests}";
+            var url = $"{Configuration.WEB_API_ROOT}/api/values/{TotalRequests}";
             var response = client.Send(new HttpRequestMessage(HttpMethod.Get, url), cancellationToken);
 
             // Read response's body


### PR DESCRIPTION
# Description
- Remove repetitive comments
  - Only the new things are annotated with comment 
- Renamed `protected` fields to use Pascal Casing
- Simplified `PrintHeader` usage by reducing the number of parameters
- Replaced `await Task.FromResult(true).ConfigureAwait(false);` to `await ValueTask.FromResult(true)`