### PR TITLE
Fix ShouldTerminateByKeyPress

### DIFF
--- a/PollyDemos/DemoBase.cs
+++ b/PollyDemos/DemoBase.cs
@@ -9,8 +9,8 @@ namespace PollyDemos
         protected int EventualFailures;
         protected int Retries;
 
-        // In the case of WPF the UserInteractive will return false
-        protected static bool ShouldTerminateByKeyPress() => Environment.UserInteractive && Console.KeyAvailable;
+        // In the case of WPF the stdIn is redirected.
+        protected static bool ShouldTerminateByKeyPress() => !Console.IsInputRedirected && Console.KeyAvailable;
 
         public virtual string Description => $"[Description for demo {GetType().Name} not yet provided.]";
 


### PR DESCRIPTION
# Description
- As it turned out the `UserInteractive` is true for both Console and WPF
- In case of WPF the console streams are redirected so, that can be used to distinguish Console from WPF