### PR TITLE
Add readme.md files to each project

### DIFF
--- a/PollyDemos/README.md
+++ b/PollyDemos/README.md
@@ -1,0 +1,65 @@
+# Polly Test Client Console
+
+- This project contains all the Polly demos.
+- This is the only project which is not runnable since it is a class library.
+
+```mermaid
+flowchart LR
+    console{{PollyTestClientConsole}}
+    wpf{{PollyTestClientWPF}}
+    lib>PollyDemos]
+    api[/PollyTestWebApi\]
+    style lib stroke:#0f0
+
+    console -- uses --> lib
+    wpf -- uses --> lib
+    lib -- invokes --> api
+```
+
+## Exposed functionalities
+
+- There are 10 synchronous demos to show the basics of Polly.
+  - Each has an asynchronous counterpart.
+- There are two extra asynchronous demos to illustrate the usage of `ConcurrencyLimiter`.
+- Each demo builds on the former one
+  - so, the comments are focused only on the new things.
+- Every demo runs until they are stopped.
+- The demos expose colored logs and statistics via a `DemoProgress` data class.
+
+## Structure
+
+- In order to keep the demos Polly focused
+  - the common parts are extracted into base classes.
+- This diagram depicts the inheritance hierarchy:
+  - _Note: not all `DemoXY` and `AsyncDemoYZ` classes were added to diagram for sake of simplicity._
+
+```mermaid
+classDiagram
+    AsyncConcurrencyLimiterDemo <|-- AsyncDemo11_MultipleConcurrencyLimiters
+    AsyncDemo <|-- AsyncDemo09_Pipeline_Fallback_Timeout_WaitAndRetry
+    SyncDemo <|-- Demo00_NoStrategy
+    AsyncDemo <|-- AsyncConcurrencyLimiterDemo
+    DemoBase <|-- AsyncDemo
+    DemoBase <|-- SyncDemo
+
+    class AsyncConcurrencyLimiterDemo{
+        #int MoreStatisticFields
+        #IssueGoodRequestAndProcessResponseAsync(client, token)
+        #IssueFaultingRequestAndProcessResponseAsync(client, token)
+    }
+    class AsyncDemo{
+        +void ExecuteAsync(token, progress)
+        #IssueRequestAndProcessResponseAsync(client, token)
+    }
+    class SyncDemo{
+        +void Execute(token, progress)
+        #IssueRequestAndProcessResponse(client, token)
+    }
+    class DemoBase{
+        #int StatisticFields
+        +string Description
+        +DemoProgress ProgressWithMessage()
+    }
+```
+- Several data classes are defined under the `OutputHelpers` directory.
+- The `Configuration` class contains the base url of the `PollyTestWebApi`.

--- a/PollyDemos/README.md
+++ b/PollyDemos/README.md
@@ -16,20 +16,17 @@ flowchart LR
     lib -- invokes --> api
 ```
 
-## Exposed functionalities
+## Exposed functionality
 
-- There are 10 synchronous demos to show the basics of Polly.
-  - Each has an asynchronous counterpart.
+- There are 10 synchronous demos to show the basics of Polly. Each has an asynchronous counterpart.
 - There are two extra asynchronous demos to illustrate the usage of `ConcurrencyLimiter`.
-- Each demo builds on the former one
-  - so, the comments are focused only on the new things.
-- Every demo runs until they are stopped.
+- Each demo builds on the former one so, the comments are focused only on the new things.
+- Every demo runs until it is stopped.
 - The demos expose colored logs and statistics via a `DemoProgress` data class.
 
 ## Structure
 
-- In order to keep the demos Polly focused
-  - the common parts are extracted into base classes.
+- In order to keep the demos Polly focused, the common parts are extracted into base classes.
 - This diagram depicts the inheritance hierarchy:
   - _Note: not all `DemoXY` and `AsyncDemoYZ` classes were added to diagram for sake of simplicity._
 
@@ -62,4 +59,4 @@ classDiagram
     }
 ```
 - Several data classes are defined under the `OutputHelpers` directory.
-- The `Configuration` class contains the base url of the `PollyTestWebApi`.
+- The `Configuration` class contains the base URL of the `PollyTestWebApi` project.

--- a/PollyDemos/README.md
+++ b/PollyDemos/README.md
@@ -19,10 +19,10 @@ flowchart LR
 ## Exposed functionality
 
 - There are 10 synchronous demos to show the basics of Polly. Each has an asynchronous counterpart.
-- There are two extra asynchronous demos to illustrate the usage of `ConcurrencyLimiter`.
+- There are two extra asynchronous demos to illustrate the usage of [`ConcurrencyLimiter`](https://www.pollydocs.org/migration-v8.html#migrating-bulkhead-policies).
 - Each demo builds on the former one so, the comments are focused only on the new things.
 - Every demo runs until it is stopped.
-- The demos expose colored logs and statistics via a `DemoProgress` data class.
+- The demos expose colored logs and statistics via a [`DemoProgress`](OutputHelpers/DemoProgress.cs) data class.
 
 ## Structure
 
@@ -58,5 +58,5 @@ classDiagram
         +DemoProgress ProgressWithMessage()
     }
 ```
-- Several data classes are defined under the `OutputHelpers` directory.
-- The `Configuration` class contains the base URL of the `PollyTestWebApi` project.
+- Several data classes are defined under the [`OutputHelpers`](OutputHelpers/) directory.
+- The [`Configuration`](Configuration.cs) class contains the base URL of the [`PollyTestWebApi`](../PollyTestWebApi/README.md) project.

--- a/PollyDemos/README.md
+++ b/PollyDemos/README.md
@@ -1,4 +1,4 @@
-# Polly Test Client Console
+# Polly Demos
 
 - This project contains all the Polly demos.
 - This is the only project which is not runnable since it is a class library.
@@ -58,5 +58,6 @@ classDiagram
         +DemoProgress ProgressWithMessage()
     }
 ```
+
 - Several data classes are defined under the [`OutputHelpers`](OutputHelpers/) directory.
 - The [`Configuration`](Configuration.cs) class contains the base URL of the [`PollyTestWebApi`](../PollyTestWebApi/README.md) project.

--- a/PollyTestClientConsole/README.md
+++ b/PollyTestClientConsole/README.md
@@ -25,16 +25,18 @@ flowchart LR
 
 ## Structure
 
-- The `Program.cs` is the main entry point.
-- To run a new demo: comment out the current one and uncomment the next.
-- To switch from the sync to async demos overwrite the `useSyncDemos` to `false`.
-- We suggest to run the demos in the same order as they are defined in this file.
+- The [`Program.cs`](Program.cs) is the main entry point.
+- To run a new demo, comment out the current one and uncomment the next.
+- To switch from the sync to async demos change the value of the  `useSyncDemos` variable to `false`.
+- We suggest to run the demos in the same order as they are defined.
 
 ## How to run?
+
 - From the `PollySamples` directory:
 ```none
 dotnet run --project PollyTestClientConsole/PollyTestClientConsole.csproj
 ```
+
 - From the `PollyTestClientConsole` directory:
 ```none
 dotnet run
@@ -43,5 +45,5 @@ dotnet run
 > [!IMPORTANT]
 > **Run the `PollyTestWebApi` as well**
 >
-> Please make sure that `PollyTestWebApi` is also running. <br/>
+> Please make sure that [`PollyTestWebApi`](../PollyTestWebApi/README.md) is also running. <br/>
 > Otherwise the demos will not work properly (you will see _connection refused_ messages).

--- a/PollyTestClientConsole/README.md
+++ b/PollyTestClientConsole/README.md
@@ -33,11 +33,13 @@ flowchart LR
 ## How to run?
 
 - From the `PollySamples` directory:
+
 ```none
 dotnet run --project PollyTestClientConsole/PollyTestClientConsole.csproj
 ```
 
 - From the `PollyTestClientConsole` directory:
+
 ```none
 dotnet run
 ```

--- a/PollyTestClientConsole/README.md
+++ b/PollyTestClientConsole/README.md
@@ -1,0 +1,47 @@
+# Polly Test Client Console
+
+- This project provides a CLI to run a Polly demo.
+
+```mermaid
+flowchart LR
+    console{{PollyTestClientConsole}}
+    wpf{{PollyTestClientWPF}}
+    lib>PollyDemos]
+    api[/PollyTestWebApi\]
+    style console stroke:#0f0
+
+    console -- uses --> lib
+    wpf -- uses --> lib
+    lib -- invokes --> api
+```
+
+## Exposed functionalities
+
+- It lets you start and stop any demo.
+- While the demo is running it prompts the logs.
+- To stop the demo press _any_ key.
+- When you stop the demo you can scrutinize the logs and check the statistics.
+- To exit from the application press _any_ key after you assessed the prompted messages.
+
+## Structure
+
+- The `Program.cs` is the main entry point.
+- To run a new demo: comment out the current one and uncomment the next.
+- To switch from the sync to async demos overwrite the `useSyncDemos` to `false`.
+- We suggest to run the demos in the same order as they are defined in this file.
+
+## How to run?
+- From the `PollySamples` directory:
+```none
+dotnet run --project PollyTestClientConsole/PollyTestClientConsole.csproj
+```
+- From the `PollyTestClientConsole` directory:
+```none
+dotnet run
+```
+
+> [!IMPORTANT]
+> **Run the `PollyTestWebApi` as well**
+>
+> Please make sure that `PollyTestWebApi` is also running. <br/>
+> Otherwise the demos will not work properly (you will see _connection refused_ messages).

--- a/PollyTestClientConsole/README.md
+++ b/PollyTestClientConsole/README.md
@@ -15,7 +15,7 @@ flowchart LR
     lib -- invokes --> api
 ```
 
-## Exposed functionalities
+## Exposed functionality
 
 - It lets you start and stop any demo.
 - While the demo is running it prompts the logs.
@@ -43,7 +43,7 @@ dotnet run
 ```
 
 > [!IMPORTANT]
-> **Run the `PollyTestWebApi` as well**
+> **Run the `PollyTestWebApi` project as well**
 >
 > Please make sure that [`PollyTestWebApi`](../PollyTestWebApi/README.md) is also running. <br/>
 > Otherwise the demos will not work properly (you will see _connection refused_ messages).

--- a/PollyTestClientWpf/README.md
+++ b/PollyTestClientWpf/README.md
@@ -40,11 +40,13 @@ flowchart LR
 ## How to run?
 
 - From the `PollySamples` directory:
+
 ```none
 dotnet run --project PollyTestClientWpf/PollyTestClientWpf.csproj
 ```
 
 - From the `PollyTestClientWpf` directory:
+
 ```none
 dotnet run
 ```

--- a/PollyTestClientWpf/README.md
+++ b/PollyTestClientWpf/README.md
@@ -15,41 +15,42 @@ flowchart LR
     lib -- invokes --> api
 ```
 
-## Exposed functionalities
+## Exposed functionality
 
-- It provides a drop down list from which you can choose which demo do you want to run.
+- It provides a dropdown list from which you can choose which demo do you want to run.
 - It shows some minimal description about the chosen demo.
-- It lets you start, stop and rerun any demo.
-- While the demo is running
-  - it prompts the logs with auto-scrolling and
+- It lets you start, stop and re-run any demo.
+- While the demo is running:
+  - it prompts the logs with auto-scrolling and;
   - it auto-updates the statistics.
-- When you stop the demo
-  - you can scrutinize the logs and
+- When you stop the demo:
+  - you can scrutinize the logs and;
   - check the final statistics.
-- When you start a new demo or restart the previous one
-  - then the logs and statistics are reset.
+- When you start a new demo or restart the previous one then the logs and statistics are reset.
 
 ## Structure
 
-- The `MainWindow.xaml` defines the UI components and their layout.
-- The `MainWindow.xaml.cs`
+- The [`MainWindow.xaml`](MainWindow.xaml) defines the UI components and their layout.
+- The [`MainWindow.xaml.cs`](MainWindow.xaml.cs)
   - handles the interactions
   - uses reflection to invoke the selected demo
-  - updates UI whenever there is a progress change
+  - updates the UI whenever there is a progress change
   - handles all sort of errors.
 
 ## How to run?
+
 - From the `PollySamples` directory:
 ```none
 dotnet run --project PollyTestClientWpf/PollyTestClientWpf.csproj
 ```
+
 - From the `PollyTestClientWpf` directory:
 ```none
 dotnet run
 ```
 
 > [!IMPORTANT]
-> **Run the `PollyTestWebApi` as well**
+> **Run the `PollyTestWebApi` project as well**
 >
-> Please make sure that `PollyTestWebApi` is also running. <br/>
+> Please make sure that [`PollyTestWebApi`](../PollyTestWebApi/README.md) is also running. <br/>
 > Otherwise the demos will not work properly (you will see _connection refused_ messages).

--- a/PollyTestClientWpf/README.md
+++ b/PollyTestClientWpf/README.md
@@ -1,0 +1,55 @@
+# Polly Test Client WPF
+
+- This project provides a GUI to walk through the Polly demos.
+
+```mermaid
+flowchart LR
+    console{{PollyTestClientConsole}}
+    wpf{{PollyTestClientWPF}}
+    lib>PollyDemos]
+    api[/PollyTestWebApi\]
+    style wpf stroke:#0f0
+
+    console -- uses --> lib
+    wpf -- uses --> lib
+    lib -- invokes --> api
+```
+
+## Exposed functionalities
+
+- It provides a drop down list from which you can choose which demo do you want to run.
+- It shows some minimal description about the chosen demo.
+- It lets you start, stop and rerun any demo.
+- While the demo is running
+  - it prompts the logs with auto-scrolling and
+  - it auto-updates the statistics.
+- When you stop the demo
+  - you can scrutinize the logs and
+  - check the final statistics.
+- When you start a new demo or restart the previous one
+  - then the logs and statistics are reset.
+
+## Structure
+
+- The `MainWindow.xaml` defines the UI components and their layout.
+- The `MainWindow.xaml.cs`
+  - handles the interactions
+  - uses reflection to invoke the selected demo
+  - updates UI whenever there is a progress change
+  - handles all sort of errors.
+
+## How to run?
+- From the `PollySamples` directory:
+```none
+dotnet run --project PollyTestClientWpf/PollyTestClientWpf.csproj
+```
+- From the `PollyTestClientWpf` directory:
+```none
+dotnet run
+```
+
+> [!IMPORTANT]
+> **Run the `PollyTestWebApi` as well**
+>
+> Please make sure that `PollyTestWebApi` is also running. <br/>
+> Otherwise the demos will not work properly (you will see _connection refused_ messages).

--- a/PollyTestWebApi/README.md
+++ b/PollyTestWebApi/README.md
@@ -1,0 +1,61 @@
+# Polly Test Web API
+
+- This project is a super-lightweight web API.
+- It is invoked by the sync and async demos.
+
+```mermaid
+flowchart LR
+    console{{PollyTestClientConsole}}
+    wpf{{PollyTestClientWPF}}
+    lib>PollyDemos]
+    api[/PollyTestWebApi\]
+
+    console -- uses --> lib
+    wpf -- uses --> lib
+    lib -- invokes --> api
+```
+
+## Exposed functionalities
+
+- It exposes three simple endpoints.
+- All of them echo back the received parameter (`{id}`) with some hard-coded prefixes.
+
+### `GET /api/Values/{id}`
+
+- It simply returns a string.
+- It is decorated with rate limiting.
+  - It allows 3 requests per 5 seconds.
+  - If the threshold is exceeded then it returns 429.
+
+### `GET /api/NonThrottledGood/{id}`
+
+- It simply returns a string.
+- As its name suggests it is NOT decorated with rate limiting.
+
+### `GET /api/NonThrottledFaulting/{id}`
+
+- It waits **5 seconds** before returns a string.
+  - It emulates slow processing.
+- As its name suggests it is NOT decorated with rate limiting.
+
+## Structure
+
+- The `Program.cs` contains the majority of the codebase
+  - the rate limiting policy definition
+  - the controllers registration
+  - and it exposes the last two endpoint via Minimal API
+- The `Controllers/ValueController.cs`
+  - contains the definition of the  `/api/Values/{id}` endpoint
+  - decorated with the rate limiting policy
+
+## How to run?
+
+- From the `PollySamples` directory:
+```none
+dotnet run --project PollyTestWebApi/PollyTestWebApi.csproj
+```
+- From the `PollyTestWebApi` directory:
+```none
+dotnet run
+```
+- The Kestrel will host the web API via the `http://localhost:45179` base Url.

--- a/PollyTestWebApi/README.md
+++ b/PollyTestWebApi/README.md
@@ -16,7 +16,7 @@ flowchart LR
     lib -- invokes --> api
 ```
 
-## Exposed functionalities
+## Exposed functionality
 
 - It exposes three simple endpoints.
 - All of them echo back the received parameter (`{id}`) with some hard-coded prefixes.
@@ -26,37 +26,41 @@ flowchart LR
 - It simply returns a string.
 - It is decorated with rate limiting.
   - It allows 3 requests per 5 seconds.
-  - If the threshold is exceeded then it returns 429.
+  - If the threshold is exceeded then it returns an HTTP 429 status code.
 
 ### `GET /api/NonThrottledGood/{id}`
 
 - It simply returns a string.
-- As its name suggests it is NOT decorated with rate limiting.
+- As its name suggests, it is **not** decorated with rate limiting.
 
 ### `GET /api/NonThrottledFaulting/{id}`
 
 - It waits **5 seconds** before returns a string.
-  - It emulates slow processing.
-- As its name suggests it is NOT decorated with rate limiting.
+- It emulates slow processing.
+- As its name suggests, it is **not** decorated with rate limiting.
 
 ## Structure
 
-- The `Program.cs` contains the majority of the codebase
+- The [`Program.cs`](Program.cs) contains the majority of the codebase
   - the rate limiting policy definition
   - the controllers registration
   - and it exposes the last two endpoint via Minimal API
-- The `Controllers/ValueController.cs`
+- The [`Controllers/ValueController.cs`](Controllers/ValuesController.cs)
   - contains the definition of the  `/api/Values/{id}` endpoint
   - decorated with the rate limiting policy
 
 ## How to run?
 
 - From the `PollySamples` directory:
+
 ```none
 dotnet run --project PollyTestWebApi/PollyTestWebApi.csproj
 ```
+
 - From the `PollyTestWebApi` directory:
+
 ```none
 dotnet run
 ```
-- The Kestrel will host the web API via the `http://localhost:45179` base Url.
+
+- The web API will be hosted with Kestrel with `http://localhost:45179` as the base URL.

--- a/PollyTestWebApi/README.md
+++ b/PollyTestWebApi/README.md
@@ -9,6 +9,7 @@ flowchart LR
     wpf{{PollyTestClientWPF}}
     lib>PollyDemos]
     api[/PollyTestWebApi\]
+    style api stroke:#0f0
 
     console -- uses --> lib
     wpf -- uses --> lib


### PR DESCRIPTION
# Description
- I've added a readme.md file to each project
- The markdown files are following the same structure
- I've also added several `mermaid` diagrams to help understand project relationships

# Previews:
- [PollyDemos](https://github.com/peter-csala/Polly-Samples/blob/migrate-readme-md/PollyDemos/README.md)
- [PollyTestWebApi](https://github.com/peter-csala/Polly-Samples/blob/migrate-readme-md/PollyTestWebApi/README.md)
- [PollyTestClientConsole](https://github.com/peter-csala/Polly-Samples/blob/migrate-readme-md/PollyTestClientConsole/README.md)
- [PollyTestClientWpf](https://github.com/peter-csala/Polly-Samples/blob/migrate-readme-md/PollyTestClientWpf/README.md) 