### PR TITLE
Migrate main readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ flowchart LR
 
 ## Want further information?
 
-- For any questions about the operation of the demos, ask on this repo [with an issue](https://github.com/App-vNext/Polly-Samples/issues/new/choose)).
+- For any questions about the operation of the demos, ask on this repo [with an issue](https://github.com/App-vNext/Polly-Samples/issues/new/choose).
 - For any questions about Polly, ask in the [Polly repository](https://www.github.com/App-vNext/Polly/issues/new/choose).
 - For full Polly syntax, see [Polly repository]((https://github.com/App-vNext/Polly#readme)) and the [Polly documentation](https://www.pollydocs.org/).
 

--- a/README.md
+++ b/README.md
@@ -2,90 +2,81 @@
 
 ![Polly logo](https://raw.github.com/App-vNext/Polly/main/Polly-Logo.png)
 
-Provides sample implementations using the [Polly library](https://www.github.com/App-vNext/Polly). The intent of this project is to help newcomers kick-start the use of [Polly](https://www.github.com/App-vNext/Polly) within their own projects.  The samples demonstrate the policies in action, against faulting endpoints
+It provides sample implementations using the [Polly library](https://www.github.com/App-vNext/Polly).
 
-> [!NOTE]
-> **Sample code migration to V8 is in progress!**
->
-> As **Polly v8** has reached **feature-complete** state it's time to update the `Polly-Samples` as well.
-> The migration process happens gradually so, we are asking for your patience while we get everything updated.
+The intent of this project is to help newcomers kick-start the use of Polly within their own projects.
 
-## About the numbered demos
+The samples demonstrate the policies in action, against faulting endpoints.
 
-### Background
+## Table of contents
 
-+ The demos run against an example 'faulting server' (also within the solution as `PollyTestWebApi`).  To simulate failure, the dummy server rejects more than 3 calls from the same IP in any five-second period (bulkhead demos excepted).
-+ Be sure to read the `<summary/>` at the top of each demo: this explains the intent of that demo, and what resilience it adds to its handling of the calls to the 'faulting server'.
-+ Sometimes the `<summary/>` also highlights what this demo _doesn't_ achieve - often picked up in the following demo. Explore the demos in sequence, for best understanding.
-+ All demos exist in both sync and async forms.
+- [Polly-Samples](#polly-samples)
+  - [Table of contents](#table-of-contents)
+  - [Projects](#projects)
+  - [Demos](#demos)
+    - [General information](#general-information)
+    - [Sequence](#sequence)
+  - [Want further information?](#want-further-information)
+  - [Slide decks](#slide-decks)
 
-### Demo sequence
+## Projects
 
-+ Demo 00 shows behaviour calling the faulting server every half-second, with _no_ Polly policies protecting the call.
-+ Demos 01-04 show various flavors of Polly retry.
-+ Demos 06-07 show retry combined with Circuit-Breaker.
-+ Demo 07 shows the Polly v5.0 `PolicyWrap` for combining policies.
-+ Demo 08 adds Polly v5.0 `Fallback`, making the call protected (in a PolicyWrap) by a Fallback, Retry, Circuitbreaker.
-+ Demo 09 shows the Polly v5.0 `Timeout` policy for an overall call timeout, in combination with `Fallback` and `WaitAndRetry`.
+The solution contains three applications and one class library.
+- `PollyTestWebApi`: This application is a web API with three endpoint. ([Further information](/PollyTestWebApi/README.md))
+- `PollyDemos`: This library contains the Polly demos. ([Further information](/PollyDemos/README.md))
+- `PollyTestClientConsole`: This application provides a CLI to test a demo. ([Further information](/PollyTestClientConsole/README.md))
+- `PollyTestClientWpf`: This application provides a GUI to walk through the demos. ([Further information](/PollyTestClientWpf/README.md))
 
-## Bulkhead isolation demos
+```mermaid
+flowchart LR
+    console{{PollyTestClientConsole}}
+    wpf{{PollyTestClientWPF}}
+    lib>PollyDemos]
+    api[/PollyTestWebApi\]
 
-### Background
-
-The bulkhead isolation demos place calls against two different endpoints on a downstream server:
-
-+ The **good** endpoint returns results in a timely manner
-+ The **faulting** endpoint simulates a faulting downstream system: it does respond, but only after a long delay.
-+ (_Note_: Unlike the other demos, there is no rate-limiting rejection of the caller.)
-
-### Demo sequence
-
-In both bulkhead demos, the upstream system makes a random mixture of calls to the **good** and **faulting** endpoints.
-
-+ In Demo 00 there is **no isolation**: calls to both the **good** and **faulting** endpoints share resources.
-  + Sooner or later, the **faulting stream of calls saturates** all resource in the caller, starving the calls to the **good** endpoint of resource too.
-  + Watch how the the calls to the **good** endpoint eventually start backing up (watch the 'pending' or 'faulting' counts climb), because the faulting stream of calls is starving the whole system of resource.
-+ In Demo 01, the calls to **faulting** and **good** endpoints are **separated by bulkhead isolation**.
-  + The faulting stream of calls still backs up and fails.
-  + But **the calls to the good endpoint are unaffected - they consistently succeed**, because they are isolated in a separate bulkhead.
-
-## Running the demos
-
-## To start the dummy faulting server (PollyTestApp)
-
-If there are problems with https and ssl trust, try running `dotnet dev-certs https --trust`.
-
-Start the dummy server, by starting `PollyTestWebApi`:
-
-```sh
-dotnet run --project PollyTestWebApi/PollyTestWebApi.csproj
+    console -- uses --> lib
+    wpf -- uses --> lib
+    lib -- invokes --> api
 ```
 
-Be sure the port number for the dummy server in `PollyDemos\Configuration.cs` matches the port on which `PollyTestApp` has started on _your_ machine (in the previous step).
+## Demos
 
-Then ...
+### General information
 
-## To run the demos - WPF (PollyTestClientWPF - only on Windows)
+- The demos run against an example 'faulting server'.
+  - To simulate failure, the dummy server rejects more than 3 calls in any five-second period.
+- Be sure to read the `<summary>` at the top of each demo.
+  - This explains the intent of that demo, and what resilience it adds to its handling of the calls to the 'faulting server'.
+- Sometimes the `<summary>` also highlights what this demo _doesn't_ achieve often picked up in the following demo.
+- Explore the demos in sequence, for best understanding.
+- All demos exist in both sync and async forms.
 
-+ Start the PollyTestClientWPF application.
-+ **Start** button starts a demo; **Stop** button stops it; **Clear** button clears the output.
-+ Many Polly policies are about handling exceptions.  If running the demos in debug mode out of Visual Studio and flow is interrupted by Visual Studio breaking on exceptions, uncheck the box "Break when this exception type is user-unhandled" in the dialog shown when Visual Studio breaks on an exception.  Or simply run without debugging.
+### Sequence
 
-## To run the demos - Console (PollyTestClientConsole - works on Mac/Linux/Windows)
+| # | Description | Sync link | Async link |
+| :-: | -- | :-: | :-: |
+| 00 | No strategy | [Here](PollyDemos/Sync/Demo00_NoStrategy.cs) | [Here](PollyDemos/Async/AsyncDemo00_NoStrategy.cs) |
+| 01 | Retry N times | [Here](PollyDemos/Sync/Demo01_RetryNTimes.cs) | [Here](PollyDemos/Async/AsyncDemo01_RetryNTimes.cs) |
+| 02 | Wait and retry N times | [Here](PollyDemos/Sync/Demo02_WaitAndRetryNTimes.cs) | [Here](PollyDemos/Async/AsyncDemo02_WaitAndRetryNTimes.cs) |
+| 03 | Wait and retry N times, N big enough to guarantee success | [Here](PollyDemos/Sync/Demo03_WaitAndRetryNTimes_WithEnoughRetries.cs) | [Here](PollyDemos/Async/AsyncDemo03_WaitAndRetryNTimes_WithEnoughRetries.cs) |
+| 04 | Wait and retry forever | [Here](PollyDemos/Sync/Demo04_WaitAndRetryForever.cs) | [Here](PollyDemos/Async/AsyncDemo04_WaitAndRetryForever.cs) |
+| 05 | Wait and retry with exponential back-off | [Here](PollyDemos/Sync/Demo05_WaitAndRetryWithExponentialBackoff.cs) | [Here](PollyDemos/Async/AsyncDemo05_WaitAndRetryWithExponentialBackoff.cs) |
+| 06 | Wait and retry nesting circuit breaker | [Here](PollyDemos/Sync/Demo06_WaitAndRetryNestingCircuitBreaker.cs) | [Here](PollyDemos/Async/AsyncDemo06_WaitAndRetryNestingCircuitBreaker.cs) |
+| 07 | Wait and retry chaining with circuit breaker by using Pipeline | [Here](PollyDemos/Sync/Demo07_WaitAndRetryNestingCircuitBreakerUsingPipeline.cs) | [Here](PollyDemos/Async/AsyncDemo07_WaitAndRetryNestingCircuitBreakerUsingPipeline.cs) |
+| 08 | Fallback, Retry, and CircuitBreaker in a Pipeline | [Here](PollyDemos/Sync/Demo08_Pipeline-Fallback-WaitAndRetry-CircuitBreaker.cs) | [Here](PollyDemos/Async/AsyncDemo08_Pipeline-Fallback-WaitAndRetry-CircuitBreaker.cs) |
+| 09 | Fallback, Timeout, and Retry in a Pipeline | [Here](PollyDemos/Sync/Demo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs) | [Here](PollyDemos/Async/AsyncDemo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs) |
+| 10 | Without isolation: Faulting calls swamp resources, <br/>also prevent good calls | - | [Here](PollyDemos/Async/AsyncDemo10_SharedConcurrencyLimiter.cs) |
+| 11 | With isolation: Faulting calls separated, <br/>do not swamp resources, good calls still succeed | - | [Here](PollyDemos/Async/AsyncDemo11_MultipleConcurrencyLimiters.cs) |
 
-```sh
-dotnet run --project PollyTestClientConsole/PollyTestClientConsole.csproj
-```
-
-+ To run a demo, uncomment the demo you wish to run in `PollyTestClientConsole\program.cs`.  Then start `PollyTestClientConsole`.
-+ Many Polly policies are about handling exceptions.  If running the demos in debug mode out of Visual Studio and flow is interrupted by Visual Studio breaking on exceptions, uncheck the box "Break when this exception type is user-unhandled" in the dialog shown when Visual Studio breaks on an exception.  Or simply run without debugging.
 
 ## Want further information?
 
-+ Any questions about the operation of the demos, ask on this repo; any questions about Polly, ask at [Polly](https://www.github.com/App-vNext/Polly).
-+ For full Polly syntax, see [Polly](https://www.github.com/App-vNext/Polly).
-+ For deeper discussions of transient fault-handling and further Polly patterns, see the [Polly documentation](https://www.pollydocs.org/)
+- Any questions about the operation of the demos, ask on this repo.
+- Any questions about Polly, ask at [Polly](https://www.github.com/App-vNext/Polly).
+- For full Polly syntax, see Polly repo and the [Polly documentation](https://www.pollydocs.org/).
 
 ## Slide decks
 
-View the [slides presented](./slides/AppvNext-DotNetFoundation-Polly-DemoSlides-Nov-2019-generic.pptx) at NDC, DevIntersections and other conferences.  You are welcome to use and adapt this presentation for not-for-profit presentations of Polly to co-workers, user groups and similar, subject to the condition that references to the .NET Foundation, App-vNext and the individual members of the Polly team are retained.
+View the [slides presented](./slides/AppvNext-DotNetFoundation-Polly-DemoSlides-Nov-2019-generic.pptx) at NDC, DevIntersections and other conferences.
+
+You are welcome to use and adapt this presentation for not-for-profit presentations of Polly to co-workers, user groups and similar, subject to the condition that references to the .NET Foundation, App-vNext and the individual members of the Polly team are retained.

--- a/README.md
+++ b/README.md
@@ -2,27 +2,16 @@
 
 ![Polly logo](https://raw.github.com/App-vNext/Polly/main/Polly-Logo.png)
 
-It provides sample implementations using the [Polly library](https://www.github.com/App-vNext/Polly).
+This repository provides sample implementations of using the [Polly library](https://www.github.com/App-vNext/Polly) in a .NET application.
 
 The intent of this project is to help newcomers kick-start the use of Polly within their own projects.
 
 The samples demonstrate the policies in action, against faulting endpoints.
 
-## Table of contents
-
-- [Polly-Samples](#polly-samples)
-  - [Table of contents](#table-of-contents)
-  - [Projects](#projects)
-  - [Demos](#demos)
-    - [General information](#general-information)
-    - [Sequence](#sequence)
-  - [Want further information?](#want-further-information)
-  - [Slide decks](#slide-decks)
-
 ## Projects
 
-The solution contains three applications and one class library.
-- `PollyTestWebApi`: This application is a web API with three endpoint. ([Further information](/PollyTestWebApi/README.md))
+The solution contains three applications and one class library:
+- `PollyTestWebApi`: This application is a web API with three endpoints. ([Further information](/PollyTestWebApi/README.md))
 - `PollyDemos`: This library contains the Polly demos. ([Further information](/PollyDemos/README.md))
 - `PollyTestClientConsole`: This application provides a CLI to test a demo. ([Further information](/PollyTestClientConsole/README.md))
 - `PollyTestClientWpf`: This application provides a GUI to walk through the demos. ([Further information](/PollyTestClientWpf/README.md))
@@ -47,33 +36,33 @@ flowchart LR
   - To simulate failure, the dummy server rejects more than 3 calls in any five-second period.
 - Be sure to read the `<summary>` at the top of each demo.
   - This explains the intent of that demo, and what resilience it adds to its handling of the calls to the 'faulting server'.
-- Sometimes the `<summary>` also highlights what this demo _doesn't_ achieve often picked up in the following demo.
-- Explore the demos in sequence, for best understanding.
+- Sometimes the `<summary>` also highlights what this demo _doesn't_ achieve, which is often picked up in the following demo.
+- Explore the demos in sequence for best understanding.
 - All demos exist in both sync and async forms.
 
 ### Sequence
 
 | # | Description | Sync link | Async link |
 | :-: | -- | :-: | :-: |
-| 00 | No strategy | [Here](PollyDemos/Sync/Demo00_NoStrategy.cs) | [Here](PollyDemos/Async/AsyncDemo00_NoStrategy.cs) |
-| 01 | Retry N times | [Here](PollyDemos/Sync/Demo01_RetryNTimes.cs) | [Here](PollyDemos/Async/AsyncDemo01_RetryNTimes.cs) |
-| 02 | Wait and retry N times | [Here](PollyDemos/Sync/Demo02_WaitAndRetryNTimes.cs) | [Here](PollyDemos/Async/AsyncDemo02_WaitAndRetryNTimes.cs) |
-| 03 | Wait and retry N times, N big enough to guarantee success | [Here](PollyDemos/Sync/Demo03_WaitAndRetryNTimes_WithEnoughRetries.cs) | [Here](PollyDemos/Async/AsyncDemo03_WaitAndRetryNTimes_WithEnoughRetries.cs) |
-| 04 | Wait and retry forever | [Here](PollyDemos/Sync/Demo04_WaitAndRetryForever.cs) | [Here](PollyDemos/Async/AsyncDemo04_WaitAndRetryForever.cs) |
-| 05 | Wait and retry with exponential back-off | [Here](PollyDemos/Sync/Demo05_WaitAndRetryWithExponentialBackoff.cs) | [Here](PollyDemos/Async/AsyncDemo05_WaitAndRetryWithExponentialBackoff.cs) |
-| 06 | Wait and retry nesting circuit breaker | [Here](PollyDemos/Sync/Demo06_WaitAndRetryNestingCircuitBreaker.cs) | [Here](PollyDemos/Async/AsyncDemo06_WaitAndRetryNestingCircuitBreaker.cs) |
-| 07 | Wait and retry chaining with circuit breaker by using Pipeline | [Here](PollyDemos/Sync/Demo07_WaitAndRetryNestingCircuitBreakerUsingPipeline.cs) | [Here](PollyDemos/Async/AsyncDemo07_WaitAndRetryNestingCircuitBreakerUsingPipeline.cs) |
-| 08 | Fallback, Retry, and CircuitBreaker in a Pipeline | [Here](PollyDemos/Sync/Demo08_Pipeline-Fallback-WaitAndRetry-CircuitBreaker.cs) | [Here](PollyDemos/Async/AsyncDemo08_Pipeline-Fallback-WaitAndRetry-CircuitBreaker.cs) |
-| 09 | Fallback, Timeout, and Retry in a Pipeline | [Here](PollyDemos/Sync/Demo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs) | [Here](PollyDemos/Async/AsyncDemo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs) |
-| 10 | Without isolation: Faulting calls swamp resources, <br/>also prevent good calls | - | [Here](PollyDemos/Async/AsyncDemo10_SharedConcurrencyLimiter.cs) |
-| 11 | With isolation: Faulting calls separated, <br/>do not swamp resources, good calls still succeed | - | [Here](PollyDemos/Async/AsyncDemo11_MultipleConcurrencyLimiters.cs) |
+| 00 | No strategy | [Code](PollyDemos/Sync/Demo00_NoStrategy.cs) | [Code](PollyDemos/Async/AsyncDemo00_NoStrategy.cs) |
+| 01 | Retry N times | [Code](PollyDemos/Sync/Demo01_RetryNTimes.cs) | [Code](PollyDemos/Async/AsyncDemo01_RetryNTimes.cs) |
+| 02 | Wait and retry N times | [Code](PollyDemos/Sync/Demo02_WaitAndRetryNTimes.cs) | [Code](PollyDemos/Async/AsyncDemo02_WaitAndRetryNTimes.cs) |
+| 03 | Wait and retry N times, N big enough to guarantee success | [Code](PollyDemos/Sync/Demo03_WaitAndRetryNTimes_WithEnoughRetries.cs) | [Code](PollyDemos/Async/AsyncDemo03_WaitAndRetryNTimes_WithEnoughRetries.cs) |
+| 04 | Wait and retry forever | [Code](PollyDemos/Sync/Demo04_WaitAndRetryForever.cs) | [Code](PollyDemos/Async/AsyncDemo04_WaitAndRetryForever.cs) |
+| 05 | Wait and retry with exponential back-off | [Code](PollyDemos/Sync/Demo05_WaitAndRetryWithExponentialBackoff.cs) | [Code](PollyDemos/Async/AsyncDemo05_WaitAndRetryWithExponentialBackoff.cs) |
+| 06 | Wait and retry nesting circuit breaker | [Code](PollyDemos/Sync/Demo06_WaitAndRetryNestingCircuitBreaker.cs) | [Code](PollyDemos/Async/AsyncDemo06_WaitAndRetryNestingCircuitBreaker.cs) |
+| 07 | Wait and retry chaining with circuit breaker by using Pipeline | [Code](PollyDemos/Sync/Demo07_WaitAndRetryNestingCircuitBreakerUsingPipeline.cs) | [Code](PollyDemos/Async/AsyncDemo07_WaitAndRetryNestingCircuitBreakerUsingPipeline.cs) |
+| 08 | Fallback, Retry, and CircuitBreaker in a Pipeline | [Code](PollyDemos/Sync/Demo08_Pipeline-Fallback-WaitAndRetry-CircuitBreaker.cs) | [Code](PollyDemos/Async/AsyncDemo08_Pipeline-Fallback-WaitAndRetry-CircuitBreaker.cs) |
+| 09 | Fallback, Timeout, and Retry in a Pipeline | [Code](PollyDemos/Sync/Demo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs) | [Code](PollyDemos/Async/AsyncDemo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs) |
+| 10 | Without isolation: Faulting calls swamp resources, <br/>also prevent good calls | - | [Code](PollyDemos/Async/AsyncDemo10_SharedConcurrencyLimiter.cs) |
+| 11 | With isolation: Faulting calls separated, <br/>do not swamp resources, good calls still succeed | - | [Code](PollyDemos/Async/AsyncDemo11_MultipleConcurrencyLimiters.cs) |
 
 
 ## Want further information?
 
-- Any questions about the operation of the demos, ask on this repo.
-- Any questions about Polly, ask at [Polly](https://www.github.com/App-vNext/Polly).
-- For full Polly syntax, see Polly repo and the [Polly documentation](https://www.pollydocs.org/).
+- For any questions about the operation of the demos, ask on this repo [with an issue](https://github.com/App-vNext/Polly-Samples/issues/new/choose)).
+- For any questions about Polly, ask in the [Polly repository](https://www.github.com/App-vNext/Polly/issues/new/choose).
+- For full Polly syntax, see [Polly repository]((https://github.com/App-vNext/Polly#readme)) and the [Polly documentation](https://www.pollydocs.org/).
 
 ## Slide decks
 


### PR DESCRIPTION
# Description
- Added `Table of contents`
- Added `Projects` section which shows the relationships and points to the projects' readme files
- Replaced the `Demo sequence` section with a markdown table
- Deleted the `Running demos` section

# Preview
https://github.com/peter-csala/Polly-Samples/blob/migrate-main-readme/README.md