### PR TITLE
Fix issue60

### DIFF
--- a/PollyDemos/Async/AsyncDemo06_WaitAndRetryNestingCircuitBreaker.cs
+++ b/PollyDemos/Async/AsyncDemo06_WaitAndRetryNestingCircuitBreaker.cs
@@ -63,6 +63,7 @@ public class AsyncDemo06_WaitAndRetryNestingCircuitBreaker : AsyncDemo
         {
             ShouldHandle = new PredicateBuilder().Handle<Exception>(),
             FailureRatio = 1.0,
+            SamplingDuration = TimeSpan.FromSeconds(2),
             MinimumThroughput = 4,
             BreakDuration = TimeSpan.FromSeconds(3),
             OnOpened = args =>

--- a/PollyDemos/Async/AsyncDemo07_WaitAndRetryNestingCircuitBreakerUsingPipeline.cs
+++ b/PollyDemos/Async/AsyncDemo07_WaitAndRetryNestingCircuitBreakerUsingPipeline.cs
@@ -38,14 +38,25 @@ public class AsyncDemo07_WaitAndRetryNestingCircuitBreakerUsingPipeline : AsyncD
         // Define a pipeline builder which will be used to compose strategies incrementally.
         var pipelineBuilder = new ResiliencePipelineBuilder();
 
-        // The order of strategy definitions has changed.
-        // Circuit breaker comes first because that will be the inner strategy.
-        // Retry comes second because that will be the outer strategy.
+        pipelineBuilder.AddRetry(new()
+        {
+            ShouldHandle = new PredicateBuilder().Handle<Exception>(ex => ex is not BrokenCircuitException),
+            MaxRetryAttempts = int.MaxValue,
+            Delay = TimeSpan.FromMilliseconds(200),
+            OnRetry = args =>
+            {
+                var exception = args.Outcome.Exception!;
+                progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
+                Retries++;
+                return default;
+            }
+        }); // We are not calling the Build method here because we will do it as a separate step to make the code cleaner.
 
         pipelineBuilder.AddCircuitBreaker(new()
         {
             ShouldHandle = new PredicateBuilder().Handle<Exception>(),
             FailureRatio = 1.0,
+            SamplingDuration = TimeSpan.FromSeconds(2),
             MinimumThroughput = 4,
             BreakDuration = TimeSpan.FromSeconds(3),
             OnOpened = args =>
@@ -69,20 +80,6 @@ public class AsyncDemo07_WaitAndRetryNestingCircuitBreakerUsingPipeline : AsyncD
                 return default;
             }
         }); // We are not calling the Build method because we want to add one more strategy to the pipeline.
-
-        pipelineBuilder.AddRetry(new()
-        {
-            ShouldHandle = new PredicateBuilder().Handle<Exception>(ex => ex is not BrokenCircuitException),
-            MaxRetryAttempts = int.MaxValue,
-            Delay = TimeSpan.FromMilliseconds(200),
-            OnRetry = args =>
-            {
-                var exception = args.Outcome.Exception!;
-                progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
-                Retries++;
-                return default;
-            }
-        }); // We are not calling the Build method here because we will do it as a separate step to make the code cleaner.
 
         // Build the pipeline since we have added all the necessary strategies to it.
         var pipeline = pipelineBuilder.Build();

--- a/PollyDemos/Async/AsyncDemo08_Pipeline-Fallback-WaitAndRetry-CircuitBreaker.cs
+++ b/PollyDemos/Async/AsyncDemo08_Pipeline-Fallback-WaitAndRetry-CircuitBreaker.cs
@@ -42,11 +42,57 @@ public class AsyncDemo08_Pipeline_Fallback_WaitAndRetry_CircuitBreaker : AsyncDe
         // Provide the return type (string) to be able to use Fallback.
         var pipelineBuilder = new ResiliencePipelineBuilder<string>();
 
+        // Define a fallback strategy: provide a substitute message to the user, for any exception.
+        pipelineBuilder.AddFallback(new()
+        {
+            ShouldHandle = new PredicateBuilder<string>().Handle<Exception>(),
+            FallbackAction = args => Outcome.FromResultAsValueTask("Please try again later [Fallback for any exception]"),
+            OnFallback = args =>
+            {
+                watch!.Stop();
+                var exception = args.Outcome.Exception!;
+                progress.Report(ProgressWithMessage($"Fallback catches eventually failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
+                eventualFailuresForOtherReasons++;
+                return default;
+            }
+        });
+
+        // Define a fallback strategy: provide a substitute message to the user, if we found the circuit was broken.
+        pipelineBuilder.AddFallback(new()
+        {
+            ShouldHandle = new PredicateBuilder<string>().Handle<BrokenCircuitException>(),
+            FallbackAction = args => Outcome.FromResultAsValueTask("Please try again later [message substituted by fallback strategy]"),
+            OnFallback = args =>
+            {
+                watch!.Stop();
+                var exception = args.Outcome.Exception!;
+                progress.Report(ProgressWithMessage($"Fallback catches failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
+                eventualFailuresDueToCircuitBreaking++;
+                return default;
+            }
+        });
+
+        pipelineBuilder.AddRetry(new()
+        {
+            // Since pipeline has a string type parameter that's why the PredicateBuilder has to have one as well.
+            ShouldHandle = new PredicateBuilder<string>().Handle<Exception>(ex => ex is not BrokenCircuitException),
+            MaxRetryAttempts = int.MaxValue,
+            Delay = TimeSpan.FromMilliseconds(200),
+            OnRetry = args =>
+            {
+                var exception = args.Outcome.Exception!;
+                progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
+                Retries++;
+                return default;
+            }
+        });
+
         pipelineBuilder.AddCircuitBreaker(new()
         {
             // Since pipeline has a string type parameter that's why the PredicateBuilder has to have one as well.
             ShouldHandle = new PredicateBuilder<string>().Handle<Exception>(),
             FailureRatio = 1.0,
+            SamplingDuration = TimeSpan.FromSeconds(2),
             MinimumThroughput = 4,
             BreakDuration = TimeSpan.FromSeconds(3),
             OnOpened = args =>
@@ -67,51 +113,6 @@ public class AsyncDemo08_Pipeline_Fallback_WaitAndRetry_CircuitBreaker : AsyncDe
             OnHalfOpened = args =>
             {
                 progress.Report(ProgressWithMessage(".Breaker logging: Half-open: Next call is a trial!", Color.Magenta));
-                return default;
-            }
-        });
-
-        pipelineBuilder.AddRetry(new()
-        {
-            // Since pipeline has a string type parameter that's why the PredicateBuilder has to have one as well.
-            ShouldHandle = new PredicateBuilder<string>().Handle<Exception>(ex => ex is not BrokenCircuitException),
-            MaxRetryAttempts = int.MaxValue,
-            Delay = TimeSpan.FromMilliseconds(200),
-            OnRetry = args =>
-            {
-                var exception = args.Outcome.Exception!;
-                progress.Report(ProgressWithMessage($"Strategy logging: {exception.Message}", Color.Yellow));
-                Retries++;
-                return default;
-            }
-        });
-
-        // Define a fallback strategy: provide a substitute message to the user, if we found the circuit was broken.
-        pipelineBuilder.AddFallback(new()
-        {
-            ShouldHandle = new PredicateBuilder<string>().Handle<BrokenCircuitException>(),
-            FallbackAction = args => Outcome.FromResultAsValueTask("Please try again later [message substituted by fallback strategy]"),
-            OnFallback = args =>
-            {
-                watch!.Stop();
-                var exception = args.Outcome.Exception!;
-                progress.Report(ProgressWithMessage($"Fallback catches failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
-                eventualFailuresDueToCircuitBreaking++;
-                return default;
-            }
-        });
-
-        // Define a fallback strategy: provide a substitute message to the user, for any exception.
-        pipelineBuilder.AddFallback(new()
-        {
-            ShouldHandle = new PredicateBuilder<string>().Handle<Exception>(),
-            FallbackAction = args => Outcome.FromResultAsValueTask("Please try again later [Fallback for any exception]"),
-            OnFallback = args =>
-            {
-                watch!.Stop();
-                var exception = args.Outcome.Exception!;
-                progress.Report(ProgressWithMessage($"Fallback catches eventually failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
-                eventualFailuresForOtherReasons++;
                 return default;
             }
         });

--- a/PollyDemos/Async/AsyncDemo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs
+++ b/PollyDemos/Async/AsyncDemo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs
@@ -40,6 +40,36 @@ public class AsyncDemo09_Pipeline_Fallback_Timeout_WaitAndRetry : AsyncDemo
         Stopwatch? watch = null;
         var pipelineBuilder = new ResiliencePipelineBuilder<string>();
 
+        // Define a fallback strategy: provide a substitute message to the user, for any exception.
+        pipelineBuilder.AddFallback(new()
+        {
+            ShouldHandle = new PredicateBuilder<string>().Handle<Exception>(),
+            FallbackAction = args => Outcome.FromResultAsValueTask("Please try again later [Fallback for any exception]"),
+            OnFallback = args =>
+            {
+                watch!.Stop();
+                var exception = args.Outcome.Exception!;
+                progress.Report(ProgressWithMessage($"Fallback catches eventually failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
+                eventualFailuresForOtherReasons++;
+                return default;
+            }
+        });
+
+        // Define a fallback strategy: provide a substitute message to the user, if we found the call was rejected due to timeout.
+        pipelineBuilder.AddFallback(new()
+        {
+            ShouldHandle = new PredicateBuilder<string>().Handle<TimeoutRejectedException>(),
+            FallbackAction = args => Outcome.FromResultAsValueTask("Please try again later [Fallback for timeout]"),
+            OnFallback = args =>
+            {
+                watch!.Stop();
+                var exception = args.Outcome.Exception!;
+                progress.Report(ProgressWithMessage($"Fallback catches failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
+                eventualFailuresDueToTimeout++;
+                return default;
+            }
+        });
+
         // Define our timeout strategy: time out after 2 seconds.
         pipelineBuilder.AddTimeout(new TimeoutStrategyOptions()
         {
@@ -67,39 +97,9 @@ public class AsyncDemo09_Pipeline_Fallback_Timeout_WaitAndRetry : AsyncDemo
             }
         });
 
-        // Define a fallback strategy: provide a substitute message to the user, if we found the call was rejected due to timeout.
-        pipelineBuilder.AddFallback(new()
-        {
-            ShouldHandle = new PredicateBuilder<string>().Handle<TimeoutRejectedException>(),
-            FallbackAction = args => Outcome.FromResultAsValueTask("Please try again later [Fallback for timeout]"),
-            OnFallback = args =>
-            {
-                watch!.Stop();
-                var exception = args.Outcome.Exception!;
-                progress.Report(ProgressWithMessage($"Fallback catches failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
-                eventualFailuresDueToTimeout++;
-                return default;
-            }
-        });
-
-        // Define a fallback strategy: provide a substitute message to the user, for any exception.
-        pipelineBuilder.AddFallback(new()
-        {
-            ShouldHandle = new PredicateBuilder<string>().Handle<Exception>(),
-            FallbackAction = args => Outcome.FromResultAsValueTask("Please try again later [Fallback for any exception]"),
-            OnFallback = args =>
-            {
-                watch!.Stop();
-                var exception = args.Outcome.Exception!;
-                progress.Report(ProgressWithMessage($"Fallback catches eventually failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
-                eventualFailuresForOtherReasons++;
-                return default;
-            }
-        });
-
         // Build the pipeline which now composes four strategies (from inner to outer):
-        // Timeout
         // Retry
+        // Timeout
         // Fallback for timeout
         // Fallback for any other exception
         var pipeline = pipelineBuilder.Build();

--- a/PollyDemos/Sync/Demo06_WaitAndRetryNestingCircuitBreaker.cs
+++ b/PollyDemos/Sync/Demo06_WaitAndRetryNestingCircuitBreaker.cs
@@ -63,6 +63,7 @@ public class Demo06_WaitAndRetryNestingCircuitBreaker : SyncDemo
         {
             ShouldHandle = new PredicateBuilder().Handle<Exception>(),
             FailureRatio = 1.0,
+            SamplingDuration = TimeSpan.FromSeconds(2),
             MinimumThroughput = 4,
             BreakDuration = TimeSpan.FromSeconds(3),
             OnOpened = args =>

--- a/PollyDemos/Sync/Demo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs
+++ b/PollyDemos/Sync/Demo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs
@@ -97,10 +97,6 @@ public class Demo09_Pipeline_Fallback_Timeout_WaitAndRetry : SyncDemo
             }
         });
 
-
-
-
-
         // Build the pipeline which now composes four strategies (from inner to outer):
         // Retry
         // Timeout

--- a/PollyDemos/Sync/Demo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs
+++ b/PollyDemos/Sync/Demo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs
@@ -40,6 +40,36 @@ public class Demo09_Pipeline_Fallback_Timeout_WaitAndRetry : SyncDemo
         Stopwatch? watch = null;
         var pipelineBuilder = new ResiliencePipelineBuilder<string>();
 
+        // Define a fallback strategy: provide a substitute message to the user, for any exception.
+        pipelineBuilder.AddFallback(new()
+        {
+            ShouldHandle = new PredicateBuilder<string>().Handle<Exception>(),
+            FallbackAction = args => Outcome.FromResultAsValueTask("Please try again later [Fallback for any exception]"),
+            OnFallback = args =>
+            {
+                watch!.Stop();
+                var exception = args.Outcome.Exception!;
+                progress.Report(ProgressWithMessage($"Fallback catches eventually failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
+                eventualFailuresForOtherReasons++;
+                return default;
+            }
+        });
+
+        // Define a fallback strategy: provide a substitute message to the user, if we found the call was rejected due to timeout.
+        pipelineBuilder.AddFallback(new()
+        {
+            ShouldHandle = new PredicateBuilder<string>().Handle<TimeoutRejectedException>(),
+            FallbackAction = args => Outcome.FromResultAsValueTask("Please try again later [Fallback for timeout]"),
+            OnFallback = args =>
+            {
+                watch!.Stop();
+                var exception = args.Outcome.Exception!;
+                progress.Report(ProgressWithMessage($"Fallback catches failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
+                eventualFailuresDueToTimeout++;
+                return default;
+            }
+        });
+
         // Define our timeout strategy: time out after 2 seconds.
         pipelineBuilder.AddTimeout(new TimeoutStrategyOptions()
         {
@@ -67,39 +97,13 @@ public class Demo09_Pipeline_Fallback_Timeout_WaitAndRetry : SyncDemo
             }
         });
 
-        // Define a fallback strategy: provide a substitute message to the user, if we found the call was rejected due to timeout.
-        pipelineBuilder.AddFallback(new()
-        {
-            ShouldHandle = new PredicateBuilder<string>().Handle<TimeoutRejectedException>(),
-            FallbackAction = args => Outcome.FromResultAsValueTask("Please try again later [Fallback for timeout]"),
-            OnFallback = args =>
-            {
-                watch!.Stop();
-                var exception = args.Outcome.Exception!;
-                progress.Report(ProgressWithMessage($"Fallback catches failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
-                eventualFailuresDueToTimeout++;
-                return default;
-            }
-        });
 
-        // Define a fallback strategy: provide a substitute message to the user, for any exception.
-        pipelineBuilder.AddFallback(new()
-        {
-            ShouldHandle = new PredicateBuilder<string>().Handle<Exception>(),
-            FallbackAction = args => Outcome.FromResultAsValueTask("Please try again later [Fallback for any exception]"),
-            OnFallback = args =>
-            {
-                watch!.Stop();
-                var exception = args.Outcome.Exception!;
-                progress.Report(ProgressWithMessage($"Fallback catches eventually failed with: {exception.Message} (after {watch.ElapsedMilliseconds}ms)", Color.Red));
-                eventualFailuresForOtherReasons++;
-                return default;
-            }
-        });
+
+
 
         // Build the pipeline which now composes four strategies (from inner to outer):
-        // Timeout
         // Retry
+        // Timeout
         // Fallback for timeout
         // Fallback for any other exception
         var pipeline = pipelineBuilder.Build();


### PR DESCRIPTION
# Related issue
- #60 

# Fix 1
- Specified `SamplingDuration` to 2 seconds instead of relying on the default 30 seconds
- Impacted demos:
  - Demo06, AsyncDemo06
  - Demo07, AsyncDemo07
  - Demo08, AsyncDemo08

# Fix 2
- The order of the strategy registration were screwed up in several places
- I've corrected the order
- Impacted demos:
  - Demo07, AsyncDemo07
  - Demo08, AsyncDemo08
  - Demo09, AsyncDemo09