### PR TITLE
Add latency hedging sample

### DIFF
--- a/PollyDemos/Demo12_LatencyHedging.cs
+++ b/PollyDemos/Demo12_LatencyHedging.cs
@@ -15,7 +15,7 @@ namespace PollyDemos;
 /// Observations:
 /// When the response arrives less than a second then the hedging will not be triggered.
 /// When the response does not arrive on time then a second (hedged) request is issued as well.
-/// Only the faster one is waited (the other one is cancelled).
+/// Only the faster one is waited for (the other one is cancelled).
 ///
 /// Take a look at the logs for PollyTestWebApi's requests to see the duplicates.
 /// </summary>

--- a/PollyDemos/Demo12_LatencyHedging.cs
+++ b/PollyDemos/Demo12_LatencyHedging.cs
@@ -1,0 +1,102 @@
+using PollyDemos.Helpers;
+using PollyDemos.OutputHelpers;
+
+namespace PollyDemos;
+
+/// <summary>
+/// Imagine a microservice with an endpoint of varying response times.
+/// Most of the times it responds in a timely manner, but sometimes it takes too long to send a response.
+///
+/// This problem is known as long tail latency. One of the well-known solutions for tail-tolerance is called hedged request.
+/// A hedged request is issued (as a mitigation action) when the original request's response is considered too slow.
+/// So, we have two pending requests: the original request and the hedged request.
+/// The faster response will be propagated back to the caller. The slower will receive the cancellation request signal.
+///
+/// Observations:
+/// When the response arrives less than a second then the hedging will not be triggered.
+/// When the response did not arrive on time then a second (hedged) request is issued as well.
+/// Only the faster one is awaited (the other is cancelled).
+///
+/// We suggest to access the PollyTestWebApi's requests log to see the duplicate requests.
+/// /// </summary>
+public class Demo12_LatencyHedging : DemoBase
+{
+    // This demo also shows how to use resilience context.
+    // We will set the request id just before we issue the original request.
+    // We access this id inside the OnHedging delegate.
+    // The resilience context is type-safe that's why we need to use ResiliencePropertyKey<int>.
+    private readonly ResiliencePropertyKey<int> requestIdKey = new("RequestId");
+
+    public override string Description =>
+        "Demonstrates a mitigation action for slow responses. If the response doesn't arrive less than a second then it will issue a new request. The hedging strategy waits for the fastest response.";
+
+    public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
+    {
+        EventualSuccesses = 0;
+        Retries = 0;
+        EventualFailures = 0;
+        TotalRequests = 0;
+
+        PrintHeader(progress);
+
+        var strategy = new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
+        {
+            MaxHedgedAttempts = 1, // Issue at most one extra hedged request
+            Delay = TimeSpan.FromSeconds(1), // Wait one second before issuing the hedged request
+            OnHedging = args =>
+            {
+                // Retrieve the request id from the context
+                var requestId = args.ActionContext.Properties.GetValue(requestIdKey, 0);
+                progress.Report(ProgressWithMessage($"Strategy logging: Slow response for request #{requestId} detected. Preparing to execute the {args.AttemptNumber} hedged action.", Color.Yellow));
+                Retries++;
+                return default;
+            }
+        }).Build();
+
+        var client = new HttpClient();
+        var internalCancel = false;
+
+        while (!(internalCancel || cancellationToken.IsCancellationRequested))
+        {
+            TotalRequests++;
+
+            // Retrieve a context from a context pool
+            ResilienceContext context = ResilienceContextPool.Shared.Get();
+
+            try
+            {
+                // Set the request id just before we issue the original request
+                context.Properties.Set(requestIdKey, TotalRequests);
+                var response = await strategy.ExecuteAsync(async _ =>
+                    await client.GetAsync($"{Configuration.WEB_API_ROOT}/api/VaryingResponseTime/{TotalRequests}", cancellationToken),
+                    context);
+
+                var responseBody = await response.Content.ReadAsStringAsync();
+                progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
+                EventualSuccesses++;
+            }
+            catch (Exception e)
+            {
+                progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                EventualFailures++;
+            }
+            finally
+            {
+                // Return the context to a context pool
+                // It needs to be returned in case of success or failure that's why we used the finally block.
+                ResilienceContextPool.Shared.Return(context);
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationToken);
+            internalCancel = ShouldTerminateByKeyPress();
+        }
+    }
+
+    public override Statistic[] LatestStatistics => new Statistic[]
+    {
+        new("Total requests made", TotalRequests),
+        new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+        new("Hedged action made to help achieve success", Retries, Color.Yellow),
+        new("Requests which eventually failed", EventualFailures, Color.Red),
+    };
+}

--- a/PollyDemos/Demo12_LatencyHedging.cs
+++ b/PollyDemos/Demo12_LatencyHedging.cs
@@ -18,7 +18,7 @@ namespace PollyDemos;
 /// Only the faster one is awaited (the other is cancelled).
 ///
 /// We suggest to access the PollyTestWebApi's requests log to see the duplicate requests.
-/// /// </summary>
+/// </summary>
 public class Demo12_LatencyHedging : DemoBase
 {
     // This demo also shows how to use resilience context.
@@ -42,7 +42,7 @@ public class Demo12_LatencyHedging : DemoBase
         var strategy = new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
         {
             MaxHedgedAttempts = 1, // Issue at most one extra hedged request
-            Delay = TimeSpan.FromSeconds(1), // Wait one second before issuing the hedged request (fallback mode)
+            Delay = TimeSpan.FromSeconds(1), // Wait one second before issuing the hedged request (latency mode)
             OnHedging = args =>
             {
                 // Retrieve the request id from the context

--- a/PollyDemos/Demo12_LatencyHedging.cs
+++ b/PollyDemos/Demo12_LatencyHedging.cs
@@ -4,19 +4,24 @@ using PollyDemos.OutputHelpers;
 namespace PollyDemos;
 
 /// <summary>
-/// Imagine a microservice with an endpoint of varying response times.
-/// Most of the time it responds in a timely manner, but sometimes it takes too long to send a response.
-///
-/// This problem is known as long tail latency. One of the well-known solutions for tail-tolerance is called hedged request.
-/// A hedged request is issued (as a mitigation action) when the original request's response is considered too slow.
-/// So, we have two pending requests: the original request and the hedged request.
-/// The faster response will be propagated back to the caller. The slower one will receive the cancellation request signal.
-///
+/// <para>
+///     Imagine a microservice with an endpoint of varying response times.<br/>
+///     Most of the time it responds in a timely manner, but sometimes it takes too long to send a response.
+/// </para>
+/// <para>
+///     This problem is known as long tail latency. One of the well-known solutions for tail-tolerance is called hedged request.<br/>
+///     A hedged request is issued (as a mitigation action) when the original request's response is considered too slow.<br/>
+///     So, we have two pending requests: the original request and the hedged request.<br/>
+///     The faster response will be propagated back to the caller. The slower one will receive the cancellation request signal.
+/// </para>
+/// <para>
 /// Observations:
-/// When the response arrives less than a second then the hedging will not be triggered.
-/// When the response does not arrive on time then a second (hedged) request is issued as well.
-/// Only the faster one is waited for (the other one is cancelled).
-///
+///     <list type="bullet">
+///         <item>When the response arrives less than a second then the hedging will not be triggered.</item>
+///         <item>When the response does not arrive on time then a second (hedged) request is issued as well.</item>
+///         <item>Only the faster one is waited for (the other one is cancelled).</item>
+///     </list>
+/// </para>
 /// Take a look at the logs for PollyTestWebApi's requests to see the duplicates.
 /// </summary>
 public class Demo12_LatencyHedging : DemoBase

--- a/PollyDemos/Demo12_LatencyHedging.cs
+++ b/PollyDemos/Demo12_LatencyHedging.cs
@@ -42,7 +42,7 @@ public class Demo12_LatencyHedging : DemoBase
         var strategy = new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
         {
             MaxHedgedAttempts = 1, // Issue at most one extra hedged request
-            Delay = TimeSpan.FromSeconds(1), // Wait one second before issuing the hedged request
+            Delay = TimeSpan.FromSeconds(1), // Wait one second before issuing the hedged request (fallback mode)
             OnHedging = args =>
             {
                 // Retrieve the request id from the context

--- a/PollyDemos/Demo12_LatencyHedging.cs
+++ b/PollyDemos/Demo12_LatencyHedging.cs
@@ -15,7 +15,7 @@ namespace PollyDemos;
 /// Observations:
 /// When the response arrives less than a second then the hedging will not be triggered.
 /// When the response does not arrive on time then a second (hedged) request is issued as well.
-/// Only the faster one is awaited (the other one is cancelled).
+/// Only the faster one is waited (the other one is cancelled).
 ///
 /// Take a look at the logs for PollyTestWebApi's requests to see the duplicates.
 /// </summary>

--- a/PollyDemos/Helpers/DemoBase.cs
+++ b/PollyDemos/Helpers/DemoBase.cs
@@ -12,7 +12,7 @@ public abstract class DemoBase
     // In the case of WPF the stdIn is redirected.
     protected static bool ShouldTerminateByKeyPress() => !Console.IsInputRedirected && Console.KeyAvailable;
 
-    public virtual string Description => $"[Description for demo {GetType().Name} not yet provided.]";
+    public abstract string Description {get;}
 
     public abstract Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress);
 

--- a/PollyDemos/Helpers/DemoBase.cs
+++ b/PollyDemos/Helpers/DemoBase.cs
@@ -12,7 +12,7 @@ public abstract class DemoBase
     // In the case of WPF the stdIn is redirected.
     protected static bool ShouldTerminateByKeyPress() => !Console.IsInputRedirected && Console.KeyAvailable;
 
-    public abstract string Description {get;}
+    public abstract string Description { get; }
 
     public abstract Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress);
 

--- a/PollyTestClientConsole/Program.cs
+++ b/PollyTestClientConsole/Program.cs
@@ -46,6 +46,8 @@ List<ConsoleMenuItem> menu = new()
         InvokeDemo<Demo10_SharedConcurrencyLimiter>),
     new("11 - With isolation: Faulting calls separated, do not swamp resources, good calls still succeed",
         InvokeDemo<Demo11_MultipleConcurrencyLimiters>),
+    new("12 - Hedging in latency mode",
+        InvokeDemo<Demo12_LatencyHedging>),
 
     new("-=Exit=-", () => Environment.Exit(0))
 };

--- a/PollyTestClientWpf/MainWindow.xaml
+++ b/PollyTestClientWpf/MainWindow.xaml
@@ -93,6 +93,10 @@
                         11 - With isolation: Faulting calls separated, do not swamp resources, good calls still succeed
                     </ComboBoxItem>
 
+                    <ComboBoxItem Name="Demo12_LatencyHedging">
+                        12 - Hedging in latency mode
+                    </ComboBoxItem>
+
                 </ComboBox>
 
                 <Label Content="Description:" />

--- a/PollyTestWebApi/Program.cs
+++ b/PollyTestWebApi/Program.cs
@@ -38,12 +38,12 @@ app.MapGet("/api/NonThrottledFaulting/{id}", async ([FromRoute] int id) =>
 
 // Register a cancellable endpoint that is not rate limited.
 // It is used by the demo 12 (hedging)
-app.MapGet("/api/VaryingResponseTime/{id}", async (CancellationToken token, [FromRoute] int id) =>
+app.MapGet("/api/VaryingResponseTime/{id}", async (CancellationToken token, [FromRoute] string id) =>
 {
     var jitter = Random.Shared.Next(-800, 800);
-    var delayMilliseconds = 1_000 + jitter;
-    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), token);
-    return $"Deferred response with ~{delayMilliseconds}ms from server to request #{id}";
+    var delay = TimeSpan.FromSeconds(1) + TimeSpan.FromMilliseconds(jitter);
+    await Task.Delay(delay, token);
+    return $"Deferred response with ~{delay.TotalMilliseconds}ms from server to request #{id}";
 });
 
 app.Run("http://localhost:45179");

--- a/PollyTestWebApi/Program.cs
+++ b/PollyTestWebApi/Program.cs
@@ -25,7 +25,7 @@ app.MapControllers();
 app.UseRateLimiter();
 
 // Register two endpoints that are not rate limited.
-// They are used by the demo 10 and 11
+// They are used by the demo 10 and 11 (concurrency limiter)
 app.MapGet("/api/NonThrottledGood/{id}", ([FromRoute] int id) =>
 {
     return $"Fast response from server to request #{id}";
@@ -35,12 +35,15 @@ app.MapGet("/api/NonThrottledFaulting/{id}", async ([FromRoute] int id) =>
     await Task.Delay(TimeSpan.FromSeconds(5));
     return $"Slow response from server to request #{id}";
 });
+
+// Register a cancellable endpoint that is not rate limited.
+// It is used by the demo 12 (hedging)
 app.MapGet("/api/VaryingResponseTime/{id}", async (CancellationToken token, [FromRoute] int id) =>
 {
     var jitter = Random.Shared.Next(-800, 800);
-    var delayMs = 1_000 + jitter;
-    await Task.Delay(TimeSpan.FromMilliseconds(delayMs), token);
-    return $"Deferred response (~{delayMs} ms) from server to request #{id}";
+    var delayMilliseconds = 1_000 + jitter;
+    await Task.Delay(TimeSpan.FromMilliseconds(delayMilliseconds), token);
+    return $"Deferred response with ~{delayMilliseconds}ms from server to request #{id}";
 });
 
 app.Run("http://localhost:45179");

--- a/PollyTestWebApi/Program.cs
+++ b/PollyTestWebApi/Program.cs
@@ -35,5 +35,12 @@ app.MapGet("/api/NonThrottledFaulting/{id}", async ([FromRoute] int id) =>
     await Task.Delay(TimeSpan.FromSeconds(5));
     return $"Slow response from server to request #{id}";
 });
+app.MapGet("/api/VaryingResponseTime/{id}", async (CancellationToken token, [FromRoute] int id) =>
+{
+    var jitter = Random.Shared.Next(-800, 800);
+    var delayMs = 1_000 + jitter;
+    await Task.Delay(TimeSpan.FromMilliseconds(delayMs), token);
+    return $"Deferred response (~{delayMs} ms) from server to request #{id}";
+});
 
 app.Run("http://localhost:45179");

--- a/PollyTestWebApi/README.md
+++ b/PollyTestWebApi/README.md
@@ -35,13 +35,13 @@ flowchart LR
 
 ### `GET /api/NonThrottledFaulting/{id}`
 
-- It waits **5 seconds** before returns a string.
+- It waits **5 seconds** before returning a string.
 - It emulates slow processing.
 - As its name suggests, it is **not** decorated with rate limiting.
 
 ### `GET /api/VaryingResponseTime/{id}`
 
-- It waits **1 second** +/- several milliseconds before returns a string.
+- It waits **1 second** +/- several milliseconds before returning a string.
 - It emulates varying response processing.
 - It is **not** decorated with rate limiting.
 

--- a/PollyTestWebApi/README.md
+++ b/PollyTestWebApi/README.md
@@ -18,7 +18,7 @@ flowchart LR
 
 ## Exposed functionality
 
-- It exposes three simple endpoints.
+- It exposes several simple endpoints.
 - All of them echo back the received parameter (`{id}`) with some hard-coded prefixes.
 
 ### `GET /api/Values/{id}`
@@ -38,6 +38,12 @@ flowchart LR
 - It waits **5 seconds** before returns a string.
 - It emulates slow processing.
 - As its name suggests, it is **not** decorated with rate limiting.
+
+### `GET /api/VaryingResponseTime/{id}`
+
+- It waits **1 second** +/- several milliseconds before returns a string.
+- It emulates varying response processing.
+- It is **not** decorated with rate limiting.
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ flowchart LR
 | 10 | Without isolation: Faulting calls swamp resources, <br/>also prevent good calls | [Code](PollyDemos/Demo10_SharedConcurrencyLimiter.cs) |
 | 11 | With isolation: Faulting calls separated, <br/>do not swamp resources, good calls still succeed | [Code](PollyDemos/Demo11_MultipleConcurrencyLimiters.cs) |
 | 12 | Hedging in latency mode | [Code](PollyDemos/Demo12_LatencyHedging.cs) |
-| 13 | Hedging in fallback mode | TBD |
-| 14 | Hedging in parallel mode | TBD |
 
 
 ## Want further information?

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ flowchart LR
 | 09 | Fallback, Timeout, and Retry in a Pipeline | [Code](PollyDemos/Demo09_Pipeline-Fallback-Timeout-WaitAndRetry.cs) |
 | 10 | Without isolation: Faulting calls swamp resources, <br/>also prevent good calls | [Code](PollyDemos/Demo10_SharedConcurrencyLimiter.cs) |
 | 11 | With isolation: Faulting calls separated, <br/>do not swamp resources, good calls still succeed | [Code](PollyDemos/Demo11_MultipleConcurrencyLimiters.cs) |
+| 12 | Hedging in latency mode | [Code](PollyDemos/Demo12_LatencyHedging.cs) |
+| 13 | Hedging in fallback mode | TBD |
+| 14 | Hedging in parallel mode | TBD |
 
 
 ## Want further information?


### PR DESCRIPTION
# Addressed issue
- #63 

# Description
- Marked the `DemoBase`'s `Description` property as `abstract` rather than `virtual`
- Added a new demo `Demo12_LatencyHedging` to demonstrate the latency mode 
- Added a new endpoint to the WebApi (specially for hedging demos)
  - Updated WebApi's readme with the new endpoint 
- Added Demo 12 to the Console and to the WPF applications
- Updated main Readme with the hedging demos 
  - Added some placeholder for future samples

# Notes
  - Later PRs will add demos for fallback and parallel hedging 