### PR TITLE
Add fallback hedging samples

### DIFF
--- a/PollyDemos/Demo13_FallbackHedging-RetryOnly.cs
+++ b/PollyDemos/Demo13_FallbackHedging-RetryOnly.cs
@@ -17,7 +17,7 @@ namespace PollyDemos;
 ///     <list type="bullet">
 ///         <item>When the original response indicates failure then a new hedged request is issued.</item>
 ///         <item>In this demo the hedging will act as a simple retry strategy.</item>
-///         <item>In the next demo hedging will act as a combined retry and fallback strategies.</item>
+///         <item>In the next demo hedging will act as a combined retry and fallback strategy.</item>
 ///     </list>
 /// </para>
 /// Take a look at the logs for PollyTestWebApi's requests to see the duplicates.
@@ -27,7 +27,7 @@ public class Demo13_FallbackHedging_RetryOnly : DemoBase
     private readonly ResiliencePropertyKey<int> requestIdKey = new("RequestId");
     private readonly ResiliencePropertyKey<int> attemptNumberKey = new("AttemptNumber");
     public override string Description =>
-        "Demonstrates a mitigation action for failed responses. If the response indicates failure then it will issue a new request. The hedging strategy waits for the first success response or it runs out of retry attempts.";
+        "Demonstrates a mitigation action for failed responses. If the response indicates failure then it will issue a new request. The hedging strategy waits for the first successful response or it runs out of retry attempts.";
 
     public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
     {
@@ -40,7 +40,7 @@ public class Demo13_FallbackHedging_RetryOnly : DemoBase
 
         var strategy = new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
         {
-            ShouldHandle = new PredicateBuilder<HttpResponseMessage>().HandleResult(res => !res.IsSuccessStatusCode), // Handle unsuccess responses
+            ShouldHandle = new PredicateBuilder<HttpResponseMessage>().HandleResult(res => !res.IsSuccessStatusCode), // Handle unsuccessful responses
             MaxHedgedAttempts = 2, // Issue at most two extra hedged requests
             Delay = TimeSpan.FromMilliseconds(-1), // Issue a hedged request if response does not indicate success (fallback mode)
             OnHedging = args =>

--- a/PollyDemos/Demo13_FallbackHedging-RetryOnly.cs
+++ b/PollyDemos/Demo13_FallbackHedging-RetryOnly.cs
@@ -5,39 +5,29 @@ namespace PollyDemos;
 
 /// <summary>
 /// <para>
-///     Imagine a microservice with an endpoint of varying response times.<br/>
-///     Most of the time it responds in a timely manner, but sometimes it takes too long to send a response.
+///     Imagine a microservice with an endpoint of varying response status codes for the same requests.<br/>
+///     Most of the time it responds with success, but other times it sends a failure response.
 /// </para>
 /// <para>
-///     This problem is known as long tail latency. One of the well-known solutions for tail-tolerance is called hedged request.<br/>
-///     A hedged request is issued (as a mitigation action) when the original request's response is considered too slow.<br/>
-///     So, we have two pending requests: the original request and the hedged request.<br/>
-///     The faster response will be propagated back to the caller. The slower one will receive the cancellation request signal.
+///     If we can assume that this is just a transient failure then retry could help.<br/>
+///     Hedging can be used in a fallback mode to issue hedged requests in case of failure.
 /// </para>
 /// <para>
 ///     Observations:
 ///     <list type="bullet">
-///         <item>When the response arrives less than a second then the hedging will not be triggered.</item>
-///         <item>When the response does not arrive on time then a second (hedged) request is issued as well.</item>
-///         <item>Only the faster one is waited for (the other one is cancelled).</item>
+///         <item>When the original response indicates failure then a new hedged request is issued.</item>
+///         <item>In this demo the hedging will act as a simple retry strategy.</item>
+///         <item>In the next demo hedging will act as a combined retry and fallback strategies.</item>
 ///     </list>
 /// </para>
 /// Take a look at the logs for PollyTestWebApi's requests to see the duplicates.
 /// </summary>
-public class Demo12_LatencyHedging : DemoBase
+public class Demo13_FallbackHedging_RetryOnly : DemoBase
 {
-    // This demo also shows how to use resilience context.
-    // We will set the request id just before we issue the original request.
-    // We access this id inside the OnHedging delegate.
-    // The resilience context is generic, so we need to use the ResiliencePropertyKey<int> type.
     private readonly ResiliencePropertyKey<int> requestIdKey = new("RequestId");
-
-    // We will set the attempt number inside the OnHedging delegate.
-    // We access this number inside the decorated callback.
     private readonly ResiliencePropertyKey<int> attemptNumberKey = new("AttemptNumber");
-
     public override string Description =>
-        "Demonstrates a mitigation action for slow responses. If the response doesn't arrive within a second then it will issue a new request. The hedging strategy waits for the fastest response.";
+        "Demonstrates a mitigation action for failed responses. If the response indicates failure then it will issue a new request. The hedging strategy waits for the first success response or it runs out of retry attempts.";
 
     public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
     {
@@ -50,18 +40,17 @@ public class Demo12_LatencyHedging : DemoBase
 
         var strategy = new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
         {
-            MaxHedgedAttempts = 1, // Issue at most one extra hedged request
-            Delay = TimeSpan.FromSeconds(1), // Wait one second before issuing the hedged request (latency mode)
+            ShouldHandle = new PredicateBuilder<HttpResponseMessage>().HandleResult(res => !res.IsSuccessStatusCode), // Handle unsuccess responses
+            MaxHedgedAttempts = 2, // Issue at most two extra hedged requests
+            Delay = TimeSpan.FromMilliseconds(-1), // Issue a hedged request if response does not indicate success (fallback mode)
             OnHedging = args =>
             {
-                // Retrieve the request id from the context
                 var requestId = $"{args.ActionContext.Properties.GetValue(requestIdKey, 0)}-{args.AttemptNumber}";
 
-                // Set the attempt number on the context
                 var hedgedRequestNumber = args.AttemptNumber + 1;
                 args.ActionContext.Properties.Set(attemptNumberKey, hedgedRequestNumber);
 
-                progress.Report(ProgressWithMessage($"Strategy logging: Slow response for request #{requestId} detected. Preparing to execute hedged action {hedgedRequestNumber}.", Color.Yellow));
+                progress.Report(ProgressWithMessage($"Strategy logging: Failed response for request #{requestId} detected. Preparing to execute hedged action {hedgedRequestNumber}.", Color.Yellow));
                 Retries++;
                 return default;
             }
@@ -74,20 +63,20 @@ public class Demo12_LatencyHedging : DemoBase
         {
             TotalRequests++;
 
-            // Retrieve a context from a context pool
             ResilienceContext context = ResilienceContextPool.Shared.Get();
 
             try
             {
-                // Set the request id just before we issue the original request
                 context.Properties.Set(requestIdKey, TotalRequests);
                 var response = await strategy.ExecuteAsync(async ctx =>
                 {
-                    // Retrieve the attempt number from the context
                     var requestId = $"{TotalRequests}-{ctx.Properties.GetValue(attemptNumberKey, 0)}";
-                    return await client.GetAsync($"{Configuration.WEB_API_ROOT}/api/VaryingResponseTime/{requestId}", cancellationToken);
-                }, context);
+                    return await client.GetAsync($"{Configuration.WEB_API_ROOT}/api/VaryingResponseStatus/{requestId}", cancellationToken);
+                },context);
 
+                // If all requests failed then hedging will return the first request's response.
+                // To handle that failure correctly, we call EnsureSuccessStatusCode to throw an HttpRequestException
+                response.EnsureSuccessStatusCode();
                 var responseBody = await response.Content.ReadAsStringAsync();
                 progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
                 EventualSuccesses++;
@@ -100,8 +89,6 @@ public class Demo12_LatencyHedging : DemoBase
             }
             finally
             {
-                // Return the context to a context pool
-                // It needs to be returned in case of success or failure that's why we used the finally block.
                 ResilienceContextPool.Shared.Return(context);
             }
 

--- a/PollyDemos/Demo14_FallbackHedging-RetryWithFallback.cs
+++ b/PollyDemos/Demo14_FallbackHedging-RetryWithFallback.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using PollyDemos.Helpers;
+using PollyDemos.OutputHelpers;
+
+namespace PollyDemos;
+
+/// <summary>
+/// <para>
+///     Imagine a microservice with an endpoint of varying response status codes for the same requests.<br/>
+///     Most of the time it responds with success, but other times it sends a failure response.
+/// </para>
+/// <para>
+///     If we can assume that this is just a transient failure then retry could help.<br/>
+///     Hedging can be used to issue the same request as a retry or craft a hedged request.
+/// </para>
+/// <para>
+///     Observations:
+///     <list type="bullet">
+///         <item>Same as in the previous demo.</item>
+///         <item>But this time hedging will act as a combined retry and fallback strategies.</item>
+///         <item><When hedging runs out of attempts, it returns a static fallback response.</item>
+///     </list>
+/// </para>
+/// Take a look at the logs for PollyTestWebApi's requests to see the duplicates.
+/// </summary>
+public class Demo14_FallbackHedging_RetryWithFallback : DemoBase
+{
+    private const int MaxRetries = 2;
+    private readonly ResiliencePropertyKey<int> requestIdKey = new("RequestId");
+    private readonly ResiliencePropertyKey<int> attemptNumberKey = new("AttemptNumber");
+    public override string Description =>
+        "Demonstrates a mitigation action for failed responses. If the response indicates failure then it will issue a new request. The hedging strategy will either return a success response or a fallback.";
+
+    public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
+    {
+        EventualSuccesses = 0;
+        Retries = 0;
+        EventualFailures = 0;
+        TotalRequests = 0;
+
+        PrintHeader(progress);
+
+        var strategy = new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
+        {
+            ShouldHandle = new PredicateBuilder<HttpResponseMessage>().HandleResult(res => !res.IsSuccessStatusCode),
+            MaxHedgedAttempts = MaxRetries,
+            Delay = TimeSpan.FromMilliseconds(-1),
+            OnHedging = args =>
+            {
+                var requestId = $"{args.ActionContext.Properties.GetValue(requestIdKey, 0)}-{args.AttemptNumber}";
+
+                var hedgedRequestNumber = args.AttemptNumber + 1;
+                args.ActionContext.Properties.Set(attemptNumberKey, hedgedRequestNumber);
+
+                progress.Report(ProgressWithMessage($"Strategy logging: Failed response for request #{requestId} detected. Preparing to execute the {hedgedRequestNumber} hedged action.", Color.Yellow));
+                Retries++;
+                return default;
+            },
+            // Alter the default behavior to perform retries until it runs out of the attempts,
+            // then it should return a fallback value
+            ActionGenerator = args =>
+            {
+                if(args.AttemptNumber != MaxRetries)
+                {
+                    // Issue the original request again as the new hedged request
+                    return () => args.Callback(args.ActionContext);
+                }
+
+                // Return a static fallback value
+                var fallbackResponse = new HttpResponseMessage(HttpStatusCode.RequestTimeout) { Content = new StringContent("Fallback response was provided")};
+                return () => Outcome.FromResultAsValueTask(fallbackResponse);
+            }
+        }).Build();
+
+        var client = new HttpClient();
+        var internalCancel = false;
+
+        while (!(internalCancel || cancellationToken.IsCancellationRequested))
+        {
+            TotalRequests++;
+
+            ResilienceContext context = ResilienceContextPool.Shared.Get();
+
+            try
+            {
+                context.Properties.Set(requestIdKey, TotalRequests);
+                var response = await strategy.ExecuteAsync(async ctx =>
+                {
+                    var requestId = $"{TotalRequests}-{ctx.Properties.GetValue(attemptNumberKey, 0)}";
+                    return await client.GetAsync($"{Configuration.WEB_API_ROOT}/api/VaryingResponseStatus/{requestId}", cancellationToken);
+                },context);
+
+                response.EnsureSuccessStatusCode();
+                var responseBody = await response.Content.ReadAsStringAsync();
+                progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
+                EventualSuccesses++;
+            }
+            catch (Exception e)
+            {
+                progress.Report(ProgressWithMessage($"Request {TotalRequests} eventually failed with: {e.Message}", Color.Red));
+                EventualFailures++;
+            }
+            finally
+            {
+                ResilienceContextPool.Shared.Return(context);
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationToken);
+            internalCancel = ShouldTerminateByKeyPress();
+        }
+    }
+
+    public override Statistic[] LatestStatistics => new Statistic[]
+    {
+        new("Total requests made", TotalRequests),
+        new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
+        new("Hedged action made to help achieve success", Retries, Color.Yellow),
+        new("Requests which eventually failed", EventualFailures, Color.Red),
+    };
+}

--- a/PollyDemos/Demo14_FallbackHedging-RetryWithFallback.cs
+++ b/PollyDemos/Demo14_FallbackHedging-RetryWithFallback.cs
@@ -10,14 +10,14 @@ namespace PollyDemos;
 ///     Most of the time it responds with success, but other times it sends a failure response.
 /// </para>
 /// <para>
-///     If we can assume that this is just a transient failure then retry could help.<br/>
+///     If we can assume that this is just a transient failure then retries could help.<br/>
 ///     Hedging can be used to issue the same request as a retry or craft a hedged request.
 /// </para>
 /// <para>
 ///     Observations:
 ///     <list type="bullet">
 ///         <item>Same as in the previous demo.</item>
-///         <item>But this time hedging will act as a combined retry and fallback strategies.</item>
+///         <item>But this time hedging will act as a combined retry and fallback strategy.</item>
 ///         <item><When hedging runs out of attempts, it returns a static fallback response.</item>
 ///     </list>
 /// </para>
@@ -56,7 +56,7 @@ public class Demo14_FallbackHedging_RetryWithFallback : DemoBase
                 Retries++;
                 return default;
             },
-            // Alter the default behavior to perform retries until it runs out of the attempts,
+            // Alter the default behavior to perform retries until it runs out of attempts,
             // then it should return a fallback value
             ActionGenerator = args =>
             {

--- a/PollyTestClientConsole/Program.cs
+++ b/PollyTestClientConsole/Program.cs
@@ -48,6 +48,10 @@ List<ConsoleMenuItem> menu = new()
         InvokeDemo<Demo11_MultipleConcurrencyLimiters>),
     new("12 - Hedging in latency mode",
         InvokeDemo<Demo12_LatencyHedging>),
+    new("13 - Hedging in fallback mode: retry only",
+        InvokeDemo<Demo13_FallbackHedging_RetryOnly>),
+    new("14 - Hedging in fallback mode: retry with fallback",
+        InvokeDemo<Demo14_FallbackHedging_RetryWithFallback>),
 
     new("-=Exit=-", () => Environment.Exit(0))
 };

--- a/PollyTestClientWpf/MainWindow.xaml
+++ b/PollyTestClientWpf/MainWindow.xaml
@@ -96,6 +96,12 @@
                     <ComboBoxItem Name="Demo12_LatencyHedging">
                         12 - Hedging in latency mode
                     </ComboBoxItem>
+                    <ComboBoxItem Name="Demo13_FallbackHedging_RetryOnly">
+                        13 - Hedging in fallback mode: retry only
+                    </ComboBoxItem>
+                    <ComboBoxItem Name="Demo14_FallbackHedging_RetryWithFallback">
+                        14 - Hedging in fallback mode: retry with fallback
+                    </ComboBoxItem>
 
                 </ComboBox>
 

--- a/PollyTestWebApi/Program.cs
+++ b/PollyTestWebApi/Program.cs
@@ -47,14 +47,14 @@ app.MapGet("/api/VaryingResponseTime/{id}", async (CancellationToken token, [Fro
 });
 
 // Register a cancellable endpoint that is not rate limited.
-// It is used by the demo 13, 14 (hedging)
+// It is used by demos 13 and 14 (hedging)
 app.MapGet("/api/VaryingResponseStatus/{id}", async (CancellationToken token, [FromRoute] string id) =>
 {
     var isSuccess = Random.Shared.NextDouble() > 0.5d;
     await Task.Delay(TimeSpan.FromSeconds(0.5));
     return isSuccess
         ? Results.Ok($"Success response with from server to request #{id}")
-        : Results.Problem($"Failed response with from server to request #{id}", statusCode: 418);
+        : Results.Problem($"Failed response with from server to request #{id}", statusCode: StatusCodes.Status418ImATeapot);
 });
 
 app.Run("http://localhost:45179");

--- a/PollyTestWebApi/Program.cs
+++ b/PollyTestWebApi/Program.cs
@@ -46,4 +46,15 @@ app.MapGet("/api/VaryingResponseTime/{id}", async (CancellationToken token, [Fro
     return $"Deferred response with ~{delay.TotalMilliseconds}ms from server to request #{id}";
 });
 
+// Register a cancellable endpoint that is not rate limited.
+// It is used by the demo 13, 14 (hedging)
+app.MapGet("/api/VaryingResponseStatus/{id}", async (CancellationToken token, [FromRoute] string id) =>
+{
+    var isSuccess = Random.Shared.NextDouble() > 0.5d;
+    await Task.Delay(TimeSpan.FromSeconds(0.5));
+    return isSuccess
+        ? Results.Ok($"Success response with from server to request #{id}")
+        : Results.Problem($"Failed response with from server to request #{id}", statusCode: 418);
+});
+
 app.Run("http://localhost:45179");

--- a/PollyTestWebApi/README.md
+++ b/PollyTestWebApi/README.md
@@ -21,28 +21,40 @@ flowchart LR
 - It exposes several simple endpoints.
 - All of them echo back the received parameter (`{id}`) with some hard-coded prefixes.
 
-### `GET /api/Values/{id}`
+### Basic scenarios
+
+#### `GET /api/Values/{id}`
 
 - It simply returns a string.
 - It is decorated with rate limiting.
   - It allows 3 requests per 5 seconds.
   - If the threshold is exceeded then it returns an HTTP 429 status code.
 
-### `GET /api/NonThrottledGood/{id}`
+### Concurrency limiter scenarios
+
+#### `GET /api/NonThrottledGood/{id}`
 
 - It simply returns a string.
 - As its name suggests, it is **not** decorated with rate limiting.
 
-### `GET /api/NonThrottledFaulting/{id}`
+#### `GET /api/NonThrottledFaulting/{id}`
 
 - It waits **5 seconds** before returning a string.
 - It emulates slow processing.
 - As its name suggests, it is **not** decorated with rate limiting.
 
-### `GET /api/VaryingResponseTime/{id}`
+### Hedging scenarios
+
+#### `GET /api/VaryingResponseTime/{id}`
 
 - It waits **1 second** +/- several milliseconds before returning a string.
 - It emulates varying response processing.
+- It is **not** decorated with rate limiting.
+
+#### `GET /api/VaryingResponseStatus/{id}`
+
+- It waits **half second** before returning a response.
+- It emulates varying response status codes.
 - It is **not** decorated with rate limiting.
 
 ## Structure

--- a/PollyTestWebApi/README.md
+++ b/PollyTestWebApi/README.md
@@ -53,7 +53,7 @@ flowchart LR
 
 #### `GET /api/VaryingResponseStatus/{id}`
 
-- It waits **half second** before returning a response.
+- It waits **half a second** before returning a response.
 - It emulates varying response status codes.
 - It is **not** decorated with rate limiting.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ flowchart LR
 | 10 | Without isolation: Faulting calls swamp resources, <br/>also prevent good calls | [Code](PollyDemos/Demo10_SharedConcurrencyLimiter.cs) |
 | 11 | With isolation: Faulting calls separated, <br/>do not swamp resources, good calls still succeed | [Code](PollyDemos/Demo11_MultipleConcurrencyLimiters.cs) |
 | 12 | Hedging in latency mode | [Code](PollyDemos/Demo12_LatencyHedging.cs) |
+| 13 | Hedging in fallback mode: retry only | [Code](PollyDemos/Demo13_FallbackHedging-RetryOnly.cs) |
+| 14 | Hedging in fallback mode: retry with fallback | [Code](PollyDemos/Demo14_FallbackHedging-RetryWithFallback.cs) |
 
 
 ## Want further information?


### PR DESCRIPTION
# Addressed issue
- #63 

# Description
- Added `Demo13_FallbackHedging-RetryOnly` to demonstrate the fallback mode without `ActionGenerator`
- Added `Demo14_FallbackHedging-RetryWithFallback` to demonstrate the fallback mode with `ActionGenerator`
- Added a new endpoint to the WebApi for fallback hedging demos

# Notes
  - Next PR will add demo(s) for parallel hedging 