### PR TITLE
Add parallel hedging sample

### DIFF
--- a/PollyDemos/Demo12_LatencyHedging.cs
+++ b/PollyDemos/Demo12_LatencyHedging.cs
@@ -22,6 +22,13 @@ namespace PollyDemos;
 ///         <item>Only the faster one is waited for (the other one is cancelled).</item>
 ///     </list>
 /// </para>
+/// <para>
+///     How to read the demo logs:
+///     <list type="bullet">
+///         <item>"Deferred ... to request #N-0": The original request was faster.</item>
+///         <item>"Deferred ... to request #N-1": The hedged request was faster.</item>
+///     </list>
+/// </para>
 /// Take a look at the logs for PollyTestWebApi's requests to see the duplicates.
 /// </summary>
 public class Demo12_LatencyHedging : DemoBase

--- a/PollyDemos/Demo14_FallbackHedging-RetryWithFallback.cs
+++ b/PollyDemos/Demo14_FallbackHedging-RetryWithFallback.cs
@@ -18,7 +18,15 @@ namespace PollyDemos;
 ///     <list type="bullet">
 ///         <item>Same as in the previous demo.</item>
 ///         <item>But this time hedging will act as a combined retry and fallback strategy.</item>
-///         <item><When hedging runs out of attempts, it returns a static fallback response.</item>
+///         <item>When hedging runs out of attempts, it returns a static fallback response.</item>
+///     </list>
+/// </para>
+/// <para>
+///     How to read the demo logs:
+///     <list type="bullet">
+///         <item>"Success ... to request #N-0": The original request succeeded.</item>
+///         <item>"Success ... to request #N-1": The first hedged request succeeded.</item>
+///         <item>"Response : Fallback response was provided": The last hedged request succeeded.</item>
 ///     </list>
 /// </para>
 /// Take a look at the logs for PollyTestWebApi's requests to see the duplicates.
@@ -52,7 +60,7 @@ public class Demo14_FallbackHedging_RetryWithFallback : DemoBase
                 var hedgedRequestNumber = args.AttemptNumber + 1;
                 args.ActionContext.Properties.Set(attemptNumberKey, hedgedRequestNumber);
 
-                progress.Report(ProgressWithMessage($"Strategy logging: Failed response for request #{requestId} detected. Preparing to execute the {hedgedRequestNumber} hedged action.", Color.Yellow));
+                progress.Report(ProgressWithMessage($"Strategy logging: Failed response for request #{requestId} detected. Preparing to execute hedged action {hedgedRequestNumber}.", Color.Yellow));
                 Retries++;
                 return default;
             },
@@ -67,7 +75,7 @@ public class Demo14_FallbackHedging_RetryWithFallback : DemoBase
                 }
 
                 // Return a static fallback value
-                var fallbackResponse = new HttpResponseMessage(HttpStatusCode.RequestTimeout) { Content = new StringContent("Fallback response was provided")};
+                var fallbackResponse = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("Fallback response was provided")};
                 return () => Outcome.FromResultAsValueTask(fallbackResponse);
             }
         }).Build();

--- a/PollyDemos/Demo15_ParallelHedging.cs
+++ b/PollyDemos/Demo15_ParallelHedging.cs
@@ -9,15 +9,15 @@ namespace PollyDemos;
 ///     Most of the time it responds with success, but other times it sends a failure response.
 /// </para>
 /// <para>
-///     If we can assume that this is just a transient failure then retry could help.<br/>
-///     Hedging can be used in a fallback mode to issue hedged requests in case of failure.
+///     If we can assume that this is just a transient failure then parallel requests could help.<br/>
+///     Hedging can be used in a parallel mode to issue all requests (original + hedged ones) simultaneously.
 /// </para>
 /// <para>
 ///     Observations:
 ///     <list type="bullet">
-///         <item>When the original response indicates failure then a new hedged request is issued.</item>
-///         <item>In this demo the hedging will act as a simple retry strategy.</item>
-///         <item>In the next demo hedging will act as a combined retry and fallback strategy.</item>
+///         <item>Hedging initiates MaxHedgedAttempts + 1 requests concurrently.</item>
+///         <item>The fastest non-failed response will be the final result.</item>
+///         <item>If all attempts fail then the final result will be the original request's response.</item>
 ///     </list>
 /// </para>
 /// <para>
@@ -26,43 +26,43 @@ namespace PollyDemos;
 ///         <item>"Success ... to request #N-0": The original request succeeded.</item>
 ///         <item>"Success ... to request #N-1": The first hedged request succeeded.</item>
 ///         <item>"Success ... to request #N-2": The last hedged request succeeded.</item>
-///         <item>"Request N eventually failed with: ...": All requests failed.</item>
+///         <item>"Request batch N eventually failed with: ...": All requests failed.</item>
 ///     </list>
 /// </para>
 /// Take a look at the logs for PollyTestWebApi's requests to see the duplicates.
 /// </summary>
-public class Demo13_FallbackHedging_RetryOnly : DemoBase
+public class Demo15_ParallelHedging : DemoBase
 {
+    // In this demo we issue requests in batches
+    private int requestBatches = 0;
     private readonly ResiliencePropertyKey<int> requestIdKey = new("RequestId");
     private readonly ResiliencePropertyKey<int> attemptNumberKey = new("AttemptNumber");
     public override string Description =>
-        "Demonstrates a mitigation action for failed responses. If the response indicates failure then it will issue a new request. The hedging strategy waits for the first successful response or it runs out of retry attempts.";
-
+        "Demonstrates a prevention action for failed responses. The hedging strategy will initiate MaxRetryAttempt plus one requests simultaneously. The assumption is that at least one would succeeded, so there is no need for retry.";
     public override async Task ExecuteAsync(CancellationToken cancellationToken, IProgress<DemoProgress> progress)
     {
         EventualSuccesses = 0;
-        Retries = 0;
         EventualFailures = 0;
         TotalRequests = 0;
+        requestBatches = 0;
 
         PrintHeader(progress);
 
         var strategy = new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
         {
-            ShouldHandle = new PredicateBuilder<HttpResponseMessage>().HandleResult(res => !res.IsSuccessStatusCode), // Handle unsuccessful responses
-            MaxHedgedAttempts = 2, // Issue at most two extra hedged requests
-            Delay = TimeSpan.FromMilliseconds(-1), // Issue a hedged request if response does not indicate success (fallback mode)
+            ShouldHandle = new PredicateBuilder<HttpResponseMessage>().HandleResult(res => !res.IsSuccessStatusCode),
+            MaxHedgedAttempts = 2, // Issue the original request and 2 more hedged requests in parallel
+            Delay = TimeSpan.Zero, // Parallel mode
             OnHedging = args =>
             {
-                var requestId = $"{args.ActionContext.Properties.GetValue(requestIdKey, 0)}-{args.AttemptNumber}";
-
+                TotalRequests++; // Hedged request
                 var hedgedRequestNumber = args.AttemptNumber + 1;
+                var requestId = $"{args.ActionContext.Properties.GetValue(requestIdKey, 0)}-{hedgedRequestNumber}";
                 args.ActionContext.Properties.Set(attemptNumberKey, hedgedRequestNumber);
 
-                progress.Report(ProgressWithMessage($"Strategy logging: Failed response for request #{requestId} detected. Preparing to execute hedged action {hedgedRequestNumber}.", Color.Yellow));
-                Retries++;
+                progress.Report(ProgressWithMessage($"Strategy logging: Preparing to execute hedged action {requestId}.", Color.Yellow));
                 return default;
-            }
+            },
         }).Build();
 
         var client = new HttpClient();
@@ -70,21 +70,21 @@ public class Demo13_FallbackHedging_RetryOnly : DemoBase
 
         while (!(internalCancel || cancellationToken.IsCancellationRequested))
         {
-            TotalRequests++;
+            requestBatches++;
+            TotalRequests++; // Original request
 
             ResilienceContext context = ResilienceContextPool.Shared.Get();
 
             try
             {
-                context.Properties.Set(requestIdKey, TotalRequests);
+                context.Properties.Set(requestIdKey, requestBatches);
                 var response = await strategy.ExecuteAsync(async ctx =>
                 {
-                    var requestId = $"{TotalRequests}-{ctx.Properties.GetValue(attemptNumberKey, 0)}";
-                    return await client.GetAsync($"{Configuration.WEB_API_ROOT}/api/VaryingResponseStatus/{requestId}", cancellationToken);
+                    var requestId = $"{requestBatches}-{ctx.Properties.GetValue(attemptNumberKey, 0)}";
+                    return await client.GetAsync($"{Configuration.WEB_API_ROOT}/api/VaryingResponseStatus/{requestId}?useJitter=true", cancellationToken);
                 },context);
 
-                // If all requests failed then hedging will return the first request's response.
-                // To handle that failure correctly, we call EnsureSuccessStatusCode to throw an HttpRequestException
+
                 response.EnsureSuccessStatusCode();
                 var responseBody = await response.Content.ReadAsStringAsync();
                 progress.Report(ProgressWithMessage($"Response : {responseBody}", Color.Green));
@@ -92,8 +92,7 @@ public class Demo13_FallbackHedging_RetryOnly : DemoBase
             }
             catch (Exception e)
             {
-                var requestId = $"{TotalRequests}-{context.Properties.GetValue(attemptNumberKey, 0)}";
-                progress.Report(ProgressWithMessage($"Request {requestId} eventually failed with: {e.Message}", Color.Red));
+                progress.Report(ProgressWithMessage($"Request batch {requestBatches} eventually failed with: {e.Message}", Color.Red));
                 EventualFailures++;
             }
             finally
@@ -109,8 +108,8 @@ public class Demo13_FallbackHedging_RetryOnly : DemoBase
     public override Statistic[] LatestStatistics => new Statistic[]
     {
         new("Total requests made", TotalRequests),
-        new("Requests which eventually succeeded", EventualSuccesses, Color.Green),
-        new("Hedged action made to help achieve success", Retries, Color.Yellow),
-        new("Requests which eventually failed", EventualFailures, Color.Red),
+        new("Request batches", requestBatches),
+        new("Succeeded request batches", EventualSuccesses, Color.Green),
+        new("Failed requests batches", EventualFailures, Color.Red),
     };
 }

--- a/PollyTestClientConsole/Program.cs
+++ b/PollyTestClientConsole/Program.cs
@@ -52,6 +52,8 @@ List<ConsoleMenuItem> menu = new()
         InvokeDemo<Demo13_FallbackHedging_RetryOnly>),
     new("14 - Hedging in fallback mode: retry with fallback",
         InvokeDemo<Demo14_FallbackHedging_RetryWithFallback>),
+    new("15 - Hedging in parallel mode",
+        InvokeDemo<Demo15_ParallelHedging>),
 
     new("-=Exit=-", () => Environment.Exit(0))
 };

--- a/PollyTestClientWpf/MainWindow.xaml
+++ b/PollyTestClientWpf/MainWindow.xaml
@@ -102,6 +102,9 @@
                     <ComboBoxItem Name="Demo14_FallbackHedging_RetryWithFallback">
                         14 - Hedging in fallback mode: retry with fallback
                     </ComboBoxItem>
+                    <ComboBoxItem Name="Demo15_ParallelHedging">
+                        15 - Hedging in parallel mode
+                    </ComboBoxItem>
 
                 </ComboBox>
 

--- a/PollyTestWebApi/Program.cs
+++ b/PollyTestWebApi/Program.cs
@@ -51,9 +51,11 @@ app.MapGet("/api/VaryingResponseTime/{id}", async (CancellationToken token, [Fro
 app.MapGet("/api/VaryingResponseStatus/{id}", async (CancellationToken token, [FromRoute] string id, [FromQuery] bool? useJitter) =>
 {
     var jitter = Random.Shared.Next(-200, 200);
-    var delay = useJitter == false
-     ? TimeSpan.FromSeconds(0.5)
-     : TimeSpan.FromSeconds(0.5) + TimeSpan.FromMilliseconds(jitter);
+    var delay = TimeSpan.FromSeconds(0.5);
+    if(useJitter == true)
+    {
+        delay += TimeSpan.FromMilliseconds(jitter);
+    }
     await Task.Delay(delay);
 
     var isSuccess = Random.Shared.NextDouble() > 0.5d;

--- a/PollyTestWebApi/Program.cs
+++ b/PollyTestWebApi/Program.cs
@@ -52,7 +52,7 @@ app.MapGet("/api/VaryingResponseStatus/{id}", async (CancellationToken token, [F
 {
     var jitter = Random.Shared.Next(-200, 200);
     var delay = TimeSpan.FromSeconds(0.5);
-    if(useJitter == true)
+    if (useJitter == true)
     {
         delay += TimeSpan.FromMilliseconds(jitter);
     }

--- a/PollyTestWebApi/Program.cs
+++ b/PollyTestWebApi/Program.cs
@@ -25,7 +25,7 @@ app.MapControllers();
 app.UseRateLimiter();
 
 // Register two endpoints that are not rate limited.
-// They are used by demo 10 and 11 (concurrency limiter)
+// They are used by demos 10 and 11 (concurrency limiter)
 app.MapGet("/api/NonThrottledGood/{id}", ([FromRoute] int id) =>
 {
     return $"Fast response from server to request #{id}";
@@ -51,7 +51,7 @@ app.MapGet("/api/VaryingResponseTime/{id}", async (CancellationToken token, [Fro
 app.MapGet("/api/VaryingResponseStatus/{id}", async (CancellationToken token, [FromRoute] string id, [FromQuery] bool? useJitter) =>
 {
     var jitter = Random.Shared.Next(-200, 200);
-    var delay = useJitter == true
+    var delay = useJitter == false
      ? TimeSpan.FromSeconds(0.5)
      : TimeSpan.FromSeconds(0.5) + TimeSpan.FromMilliseconds(jitter);
     await Task.Delay(delay);

--- a/PollyTestWebApi/Program.cs
+++ b/PollyTestWebApi/Program.cs
@@ -25,7 +25,7 @@ app.MapControllers();
 app.UseRateLimiter();
 
 // Register two endpoints that are not rate limited.
-// They are used by the demo 10 and 11 (concurrency limiter)
+// They are used by demo 10 and 11 (concurrency limiter)
 app.MapGet("/api/NonThrottledGood/{id}", ([FromRoute] int id) =>
 {
     return $"Fast response from server to request #{id}";
@@ -47,11 +47,16 @@ app.MapGet("/api/VaryingResponseTime/{id}", async (CancellationToken token, [Fro
 });
 
 // Register a cancellable endpoint that is not rate limited.
-// It is used by demos 13 and 14 (hedging)
-app.MapGet("/api/VaryingResponseStatus/{id}", async (CancellationToken token, [FromRoute] string id) =>
+// It is used by demos 13, 14 and 15 (hedging)
+app.MapGet("/api/VaryingResponseStatus/{id}", async (CancellationToken token, [FromRoute] string id, [FromQuery] bool? useJitter) =>
 {
+    var jitter = Random.Shared.Next(-200, 200);
+    var delay = useJitter == true
+     ? TimeSpan.FromSeconds(0.5)
+     : TimeSpan.FromSeconds(0.5) + TimeSpan.FromMilliseconds(jitter);
+    await Task.Delay(delay);
+
     var isSuccess = Random.Shared.NextDouble() > 0.5d;
-    await Task.Delay(TimeSpan.FromSeconds(0.5));
     return isSuccess
         ? Results.Ok($"Success response with from server to request #{id}")
         : Results.Problem($"Failed response with from server to request #{id}", statusCode: StatusCodes.Status418ImATeapot);

--- a/PollyTestWebApi/README.md
+++ b/PollyTestWebApi/README.md
@@ -53,7 +53,7 @@ flowchart LR
 
 #### `GET /api/VaryingResponseStatus/{id}`
 
-- It waits **half a second** before returning a response.
+- It waits **half a second** (optionally +/- several milliseconds) before returning a response.
 - It emulates varying response status codes.
 - It is **not** decorated with rate limiting.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ flowchart LR
 | 12 | Hedging in latency mode | [Code](PollyDemos/Demo12_LatencyHedging.cs) |
 | 13 | Hedging in fallback mode: retry only | [Code](PollyDemos/Demo13_FallbackHedging-RetryOnly.cs) |
 | 14 | Hedging in fallback mode: retry with fallback | [Code](PollyDemos/Demo14_FallbackHedging-RetryWithFallback.cs) |
+| 15 | Hedging in parallel mode | [Code](PollyDemos/Demo15_ParallelHedging.cs) |
 
 
 ## Want further information?


### PR DESCRIPTION
# Addressed issue
- #63 

# Description
- Added `Demo15_ParallelHedging` to demonstrate the parallel mode
- Fixed a bug in `Demo14_FallbackHedging-RetryWithFallback`
- Added a _How to read the demo logs_ section to each hedging demos' summary 