### PR TITLE
Use polly 8.1.0

### DIFF
--- a/PollyDemos/PollyDemos.csproj
+++ b/PollyDemos/PollyDemos.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Polly" Version="8.0.0" />
-    <PackageReference Include="Polly.RateLimiting" Version="8.0.0" />
+    <PackageReference Include="Polly.Core" Version="8.1.0" />
+    <PackageReference Include="Polly.RateLimiting" Version="8.1.0" />
     <Using Include="Polly" />
   </ItemGroup>
 </Project>

--- a/PollyTestWebApi/README.md
+++ b/PollyTestWebApi/README.md
@@ -59,13 +59,14 @@ flowchart LR
 
 ## Structure
 
-- The [`Program.cs`](Program.cs) contains the majority of the codebase
-  - the rate limiting policy definition
-  - the controllers registration
-  - and it exposes the last two endpoint via Minimal API
 - The [`Controllers/ValueController.cs`](Controllers/ValuesController.cs)
   - contains the definition of the  `/api/Values/{id}` endpoint
   - decorated with the rate limiting policy
+- The [`Program.cs`](Program.cs) contains the majority of the codebase
+  - the rate limiting policy definition
+  - the controllers registration
+  - and it exposes the rest of the endpoints via Minimal API
+
 
 ## How to run?
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The samples demonstrate the policies in action, against faulting endpoints.
 ## Projects
 
 The solution contains three applications and one class library:
-- `PollyTestWebApi`: This application is a web API with three endpoints. ([Further information](/PollyTestWebApi/README.md))
+- `PollyTestWebApi`: This application is a web API with several endpoints. ([Further information](/PollyTestWebApi/README.md))
 - `PollyDemos`: This library contains the Polly demos. ([Further information](/PollyDemos/README.md))
 - `PollyTestClientConsole`: This application provides a CLI to walk through the demos. ([Further information](/PollyTestClientConsole/README.md))
 - `PollyTestClientWpf`: This application provides a GUI to walk through the demos. ([Further information](/PollyTestClientWpf/README.md))


### PR DESCRIPTION
- Replaced `Polly` package to `Polly.Core`
- Changed  the version of the `Polly` packages to 8.1.0
- Fix the quantity of the endpoints in the readme files  